### PR TITLE
feat(types): derive TypeScript bindings for shared models

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+TS_RS_LARGE_INT = "number"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "strum",
  "tokio",
  "tracing",
+ "ts-rs",
  "url",
 ]
 
@@ -444,6 +445,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -455,6 +457,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -466,6 +469,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -477,6 +481,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -488,6 +493,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -499,6 +505,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -510,6 +517,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -521,6 +529,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -532,6 +541,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -543,6 +553,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -554,6 +565,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -565,6 +577,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -576,6 +589,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -587,6 +601,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "ts-rs",
 ]
 
 [[package]]
@@ -2793,6 +2808,28 @@ dependencies = [
  "target-triple",
  "termcolor",
  "toml",
+]
+
+[[package]]
+name = "ts-rs"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756050066659291d47a554a9f558125db17428b073c5ffce1daf5dcb0f7231d8"
+dependencies = [
+ "thiserror 2.0.18",
+ "ts-rs-macros",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d90eea51bc7988ef9e674bf80a85ba6804739e535e9cab48e4bb34a8b652aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "termcolor",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ measurements = { version = "0.11", features = ["serde"] }
 reqwest = { version = "0.13.3", features = ["json", "gzip", "rustls", "multipart", "stream"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+ts-rs = { version = "12.0.1", features = ["no-serde-warnings"] }
 tokio = { version = "1.50", features = ["full"] }
 url = "2.5"
 async-trait = "0.1"

--- a/asic-rs-core/Cargo.toml
+++ b/asic-rs-core/Cargo.toml
@@ -19,6 +19,7 @@ async-trait.workspace = true
 anyhow.workspace  = true
 reqwest.workspace  = true
 serde_json.workspace  = true
+ts-rs.workspace = true
 tracing.workspace  = true
 tokio.workspace = true
 futures.workspace = true

--- a/asic-rs-core/src/config/fan.rs
+++ b/asic-rs-core/src/config/fan.rs
@@ -1,9 +1,10 @@
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
 #[cfg_attr(feature = "python", pyclass(skip_from_py_object, module = "asic_rs"))]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, TS)]
 /// Fan control mode.
 pub enum FanMode {
     /// Firmware-managed fan control using a target temperature.
@@ -13,7 +14,7 @@ pub enum FanMode {
 }
 
 #[cfg_attr(feature = "python", pyclass(skip_from_py_object, module = "asic_rs"))]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS)]
 #[serde(tag = "mode", rename_all = "PascalCase")]
 /// Desired fan control configuration.
 ///

--- a/asic-rs-core/src/config/pools.rs
+++ b/asic-rs-core/src/config/pools.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
 use crate::data::pool::{PoolGroupData, PoolURL};
 
@@ -12,7 +13,7 @@ use crate::data::pool::{PoolGroupData, PoolURL};
     feature = "python",
     asic_rs_pydantic::py_pydantic_model(new, name = "Pool")
 )]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
 /// A writable mining pool endpoint.
 pub struct PoolConfig {
     /// Pool URL including scheme, host, port, and optional Stratum V2 pubkey.
@@ -32,7 +33,7 @@ pub struct PoolConfig {
     feature = "python",
     asic_rs_pydantic::py_pydantic_model(new, name = "PoolGroup")
 )]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
 /// A writable group of mining pools.
 ///
 /// Some firmwares support multiple pool groups with quota-based selection. For

--- a/asic-rs-core/src/config/scaling.rs
+++ b/asic-rs-core/src/config/scaling.rs
@@ -1,13 +1,14 @@
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
 #[cfg_attr(
     feature = "python",
     pyclass(from_py_object, get_all, module = "asic_rs")
 )]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
 /// Power or performance scaling configuration.
 pub struct ScalingConfig {
     /// Scaling step size used by the firmware.

--- a/asic-rs-core/src/config/temperature.rs
+++ b/asic-rs-core/src/config/temperature.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
 #[cfg_attr(
     feature = "python",
@@ -15,7 +16,7 @@ use serde::{Deserialize, Serialize};
     feature = "python",
     asic_rs_pydantic::py_pydantic_model(new, name = "TemperatureConfig")
 )]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
 /// Configured thermal limits of the miner (°C).
 ///
 /// Mirrors the Braiins OS layout. Fields are optional because not every

--- a/asic-rs-core/src/config/tuning.rs
+++ b/asic-rs-core/src/config/tuning.rs
@@ -1,12 +1,13 @@
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
 use crate::data::miner::TuningTarget;
 
 #[cfg_attr(feature = "python", pyclass(skip_from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
 /// Desired firmware tuning target.
 ///
 /// A tuning config can target a power limit, a hashrate, or a named mining

--- a/asic-rs-core/src/data/board.rs
+++ b/asic-rs-core/src/data/board.rs
@@ -4,6 +4,7 @@ use measurements::{Frequency, Temperature, Voltage};
 #[cfg(feature = "python")]
 use pyo3::pyclass;
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
 use super::{
     hashrate::HashRate,
@@ -12,7 +13,7 @@ use super::{
 
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model(getters))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, TS)]
 /// Per-chip telemetry for a hashboard.
 pub struct ChipData {
     /// The position of the chip on the board, indexed from 0
@@ -22,14 +23,17 @@ pub struct ChipData {
     /// The current chip temperature
     #[serde(serialize_with = "serialize_temperature")]
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
     pub temperature: Option<Temperature>,
     /// The voltage set point for this chip
     #[serde(serialize_with = "serialize_voltage")]
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
     pub voltage: Option<Voltage>,
     /// The frequency set point for this chip
     #[serde(serialize_with = "serialize_frequency")]
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
     pub frequency: Option<Frequency>,
     /// Whether this chip is tuned and optimizations have completed
     pub tuned: Option<bool>,
@@ -39,7 +43,7 @@ pub struct ChipData {
 
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model(getters))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, TS)]
 /// Per-hashboard telemetry for a miner.
 pub struct BoardData {
     /// The board position in the miner, indexed from 0
@@ -51,14 +55,17 @@ pub struct BoardData {
     /// The board temperature, also sometimes called PCB temperature
     #[serde(serialize_with = "serialize_temperature")]
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
     pub board_temperature: Option<Temperature>,
     /// The temperature of the coolest / first-in-chain chip on the board
     #[serde(serialize_with = "serialize_temperature")]
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
     pub inlet_chip_temperature: Option<Temperature>,
     /// The temperature of the hottest / last-in-chain chip on the board
     #[serde(serialize_with = "serialize_temperature")]
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
     pub outlet_chip_temperature: Option<Temperature>,
     /// The expected number of chips on this board
     pub expected_chips: Option<u16>,
@@ -72,10 +79,12 @@ pub struct BoardData {
     /// The average voltage or voltage set point of this board
     #[serde(serialize_with = "serialize_voltage")]
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
     pub voltage: Option<Voltage>,
     /// The average frequency or frequency set point of this board
     #[serde(serialize_with = "serialize_frequency")]
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
     pub frequency: Option<Frequency>,
     /// Whether this board has been tuned and optimizations have completed
     pub tuned: Option<bool>,
@@ -111,7 +120,7 @@ impl BoardData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[cfg_attr(
     feature = "python",
     pyclass(from_py_object, get_all, module = "asic_rs")

--- a/asic-rs-core/src/data/capabilities.rs
+++ b/asic-rs-core/src/data/capabilities.rs
@@ -9,13 +9,14 @@
 #[cfg(feature = "python")]
 use pyo3::pyclass;
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
 use super::miner::TuningTarget;
 
 /// Factory tuning envelope for power-target tuning.
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model(getters))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, TS)]
 pub struct PowerTuningCapabilities {
     /// The factory default power target, i.e. the value tuning starts from.
     pub default: Option<TuningTarget>,
@@ -28,7 +29,7 @@ pub struct PowerTuningCapabilities {
 /// Factory tuning envelope for hashrate-target tuning.
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model(getters))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, TS)]
 pub struct HashRateTuningCapabilities {
     /// The factory default hashrate target, i.e. the value tuning starts from.
     pub default: Option<TuningTarget>,
@@ -41,7 +42,7 @@ pub struct HashRateTuningCapabilities {
 /// Factory tuning envelope for preset / mining-mode tuning.
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model(getters))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, TS)]
 pub struct PresetTuningCapabilities {
     /// The factory default preset, when one is marked as default.
     pub default: Option<TuningTarget>,
@@ -56,7 +57,7 @@ pub struct PresetTuningCapabilities {
 /// tuned to" instead of a flat list of per-aspect fields.
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model(getters))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, TS)]
 pub struct TuningCapabilities {
     /// Power-target tuning envelope, when the firmware tunes by power.
     pub power: Option<PowerTuningCapabilities>,

--- a/asic-rs-core/src/data/device.rs
+++ b/asic-rs-core/src/data/device.rs
@@ -2,10 +2,11 @@
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use strum::{Display as StrumDisplay, EnumString};
+use ts_rs::TS;
 
 use crate::traits::{firmware::MinerFirmware, model::MinerModel};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model(getters))]
 /// Static identity and hardware information for a miner model.
@@ -37,7 +38,7 @@ impl DeviceInfo {
 
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model(getters))]
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Default, TS)]
 /// Expected hardware counts for a miner model.
 pub struct MinerHardware {
     /// Expected number of fans.
@@ -87,7 +88,7 @@ impl MinerHardware {
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", derive(asic_rs_pydantic::PyPydanticEnum))]
 #[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, StrumDisplay, EnumString,
+    Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, StrumDisplay, EnumString, TS,
 )]
 /// Mining hash algorithm.
 pub enum HashAlgorithm {

--- a/asic-rs-core/src/data/fan.rs
+++ b/asic-rs-core/src/data/fan.rs
@@ -3,12 +3,13 @@ use measurements::AngularVelocity;
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use serialize::serialize_angular_velocity;
+use ts_rs::TS;
 
 use crate::data::serialize;
 
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model(getters))]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 /// Runtime fan telemetry.
 pub struct FanData {
     /// The position or index of the fan as seen by the device
@@ -17,5 +18,6 @@ pub struct FanData {
     /// The RPM of the fan
     #[serde(serialize_with = "serialize_angular_velocity")]
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional, type = "number")]
     pub rpm: Option<AngularVelocity>,
 }

--- a/asic-rs-core/src/data/hashrate.rs
+++ b/asic-rs-core/src/data/hashrate.rs
@@ -14,10 +14,11 @@ use pyo3::{
     types::{PyAnyMethods, PyType},
 };
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", derive(asic_rs_pydantic::PyPydanticEnum))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, TS)]
 /// Unit used to represent a [`HashRate`] value.
 pub enum HashRateUnit {
     /// Hashes per second.
@@ -181,7 +182,7 @@ impl HashRateUnit {
     pyclass(from_py_object, get_all, module = "asic_rs")
 )]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
 /// Hashrate value with unit and mining algorithm.
 pub struct HashRate {
     /// The current amount of hashes being computed

--- a/asic-rs-core/src/data/message.rs
+++ b/asic-rs-core/src/data/message.rs
@@ -4,10 +4,11 @@ use std::fmt::Formatter;
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
+use ts_rs::TS;
 
 #[cfg_attr(feature = "python", pyclass(from_py_object, str, module = "asic_rs"))]
 #[cfg_attr(feature = "python", derive(asic_rs_pydantic::PyPydanticEnum))]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Display, EnumString)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Display, EnumString, TS)]
 /// Severity for a miner-reported message.
 pub enum MessageSeverity {
     /// Error condition.
@@ -24,7 +25,7 @@ pub enum MessageSeverity {
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", derive(asic_rs_pydantic::PyPydanticTaggedEnum))]
 #[cfg_attr(feature = "python", pydantic(discriminator = "type"))]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "type")]
 /// Miner component referenced by an error or status message.
 pub enum MinerComponent {
@@ -155,7 +156,7 @@ impl MinerComponent {
     pyclass(from_py_object, get_all, module = "asic_rs")
 )]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model)]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 /// Message, warning, or error reported by a miner.
 pub struct MinerMessage {
     /// The time this message was generated or occurred

--- a/asic-rs-core/src/data/miner.rs
+++ b/asic-rs-core/src/data/miner.rs
@@ -5,6 +5,7 @@ use measurements::{Power, Temperature};
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
 use super::{
     board::{BoardData, MinerControlBoard},
@@ -20,11 +21,11 @@ use crate::data::{
     serialize::{serialize_macaddr, serialize_power, serialize_temperature},
 };
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 /// Firmware tuning target reported by a miner or requested by configuration.
 pub enum TuningTarget {
     /// Target a power limit.
-    Power(Power),
+    Power(#[ts(type = "{ watts: number }")] Power),
     /// Target a hashrate.
     HashRate(HashRate),
     /// Target a named mining mode.
@@ -41,7 +42,7 @@ impl TuningTarget {
 #[cfg_attr(feature = "python", pyclass(from_py_object, str, module = "asic_rs"))]
 #[cfg_attr(feature = "python", derive(asic_rs_pydantic::PyPydanticEnum))]
 #[derive(
-    Debug, Clone, Copy, PartialEq, Serialize, Deserialize, strum::Display, strum::EnumString,
+    Debug, Clone, Copy, PartialEq, Serialize, Deserialize, strum::Display, strum::EnumString, TS,
 )]
 /// Firmware-defined mining performance mode.
 pub enum MiningMode {
@@ -58,7 +59,7 @@ pub enum MiningMode {
 
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model(getters))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 /// Standardized telemetry snapshot for one miner.
 pub struct MinerData {
     /// The schema version of this MinerData object, for use in external APIs
@@ -72,6 +73,7 @@ pub struct MinerData {
         serialize_with = "serialize_macaddr",
         deserialize_with = "deserialize_macaddr"
     )]
+    #[ts(type = "string | null")]
     pub mac: Option<MacAddr>,
     /// Hardware information about this miner
     pub device_info: DeviceInfo,
@@ -105,15 +107,19 @@ pub struct MinerData {
     pub psu_fans: Vec<FanData>,
     /// The average temperature across all chips in the miner
     #[serde(serialize_with = "serialize_temperature")]
+    #[ts(type = "number | null")]
     pub average_temperature: Option<Temperature>,
     /// The environment temperature of the miner, such as air temperature or immersion fluid temperature
     #[serde(serialize_with = "serialize_temperature")]
+    #[ts(type = "number | null")]
     pub fluid_temperature: Option<Temperature>,
     /// The coolant exhaust temperature, only for water-cooled miners with dedicated sensors
     #[serde(serialize_with = "serialize_temperature")]
+    #[ts(type = "number | null")]
     pub outlet_fluid_temperature: Option<Temperature>,
     /// The current power consumption of the miner
     #[serde(serialize_with = "serialize_power")]
+    #[ts(type = "number | null")]
     pub wattage: Option<Power>,
     /// The current manual tuning percent of full power (100 = unthrottled), where supported
     pub tuning_percent: Option<u8>,
@@ -131,6 +137,7 @@ pub struct MinerData {
     /// Any message on the miner, including errors
     pub messages: Vec<MinerMessage>,
     /// The total uptime of the miner's system
+    #[ts(type = "{ secs: number, nanos: number } | null")]
     pub uptime: Option<Duration>,
     /// Whether the hashing process is currently running,
     /// false if paused, true if running, even if the hashrate is 0

--- a/asic-rs-core/src/data/pool.rs
+++ b/asic-rs-core/src/data/pool.rs
@@ -8,11 +8,12 @@ use asic_rs_pydantic::{PyPydanticType, PydanticSchemaMode, get_required_field};
 #[cfg(feature = "python")]
 use pyo3::{prelude::*, types::PyAnyMethods};
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 use url::Url;
 
 #[cfg_attr(feature = "python", pyclass(from_py_object, str, module = "asic_rs"))]
 #[cfg_attr(feature = "python", derive(asic_rs_pydantic::PyPydanticEnum))]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 /// Mining pool URL scheme.
 pub enum PoolScheme {
     /// Stratum V1 over TCP.
@@ -73,7 +74,7 @@ impl FromStr for PoolScheme {
         no_repr
     )
 )]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 /// Parsed mining pool URL.
 pub struct PoolURL {
     /// The scheme being used to connect to this pool
@@ -135,7 +136,7 @@ impl Display for PoolURL {
     pyclass(from_py_object, get_all, module = "asic_rs")
 )]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model)]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 /// Runtime status for one configured pool.
 pub struct PoolData {
     /// Pool position in the firmware configuration.
@@ -159,7 +160,7 @@ pub struct PoolData {
     pyclass(from_py_object, get_all, module = "asic_rs")
 )]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model)]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 /// Runtime status for a group of configured pools.
 pub struct PoolGroupData {
     /// Pool group name.

--- a/asic-rs-makes/antminer/Cargo.toml
+++ b/asic-rs-makes/antminer/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 strum.workspace = true
 serde_json.workspace = true
 

--- a/asic-rs-makes/antminer/src/hardware.rs
+++ b/asic-rs-makes/antminer/src/hardware.rs
@@ -3,6 +3,7 @@ use asic_rs_core::data::{board::MinerControlBoard, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::AntMinerModel;
 
@@ -242,7 +243,7 @@ impl From<AntMinerModel> for MinerHardware {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum AntMinerControlBoard {
     #[serde(rename = "Xilinx")]
     Xilinx,

--- a/asic-rs-makes/antminer/src/models.rs
+++ b/asic-rs-makes/antminer/src/models.rs
@@ -4,8 +4,9 @@ use asic_rs_core::errors::ModelSelectionError;
 use asic_rs_core::traits::model::MinerModel;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum AntMinerModel {
     #[serde(alias = "ANTMINER D3")]
     D3,

--- a/asic-rs-makes/auradine/Cargo.toml
+++ b/asic-rs-makes/auradine/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 strum.workspace = true
 serde_json.workspace = true
 

--- a/asic-rs-makes/auradine/src/hardware.rs
+++ b/asic-rs-makes/auradine/src/hardware.rs
@@ -1,6 +1,7 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::AuradineModel;
 
@@ -26,7 +27,7 @@ impl From<AuradineModel> for MinerHardware {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum AuradineControlBoard {
     #[serde(rename = "T0")]
     T0,

--- a/asic-rs-makes/auradine/src/models.rs
+++ b/asic-rs-makes/auradine/src/models.rs
@@ -4,8 +4,9 @@ use asic_rs_core::errors::ModelSelectionError;
 use asic_rs_core::traits::model::MinerModel;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum AuradineModel {
     #[serde(alias = "AI2500")]
     AI2500,

--- a/asic-rs-makes/avalon/Cargo.toml
+++ b/asic-rs-makes/avalon/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 strum.workspace = true
 serde_json.workspace = true
 

--- a/asic-rs-makes/avalon/src/hardware.rs
+++ b/asic-rs-makes/avalon/src/hardware.rs
@@ -1,6 +1,7 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::AvalonMinerModel;
 
@@ -96,7 +97,7 @@ impl From<AvalonMinerModel> for MinerHardware {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum AvalonMinerControlBoard {
     #[serde(rename = "MM3v2X3")]
     MM3v2X3,

--- a/asic-rs-makes/avalon/src/models.rs
+++ b/asic-rs-makes/avalon/src/models.rs
@@ -4,8 +4,9 @@ use std::str::FromStr;
 use asic_rs_core::errors::ModelSelectionError;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, Display, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Display, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, TS)]
 pub enum AvalonMinerModel {
     #[serde(alias = "721")]
     Avalon721,

--- a/asic-rs-makes/bitaxe/Cargo.toml
+++ b/asic-rs-makes/bitaxe/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 strum.workspace = true
 serde_json.workspace = true
 

--- a/asic-rs-makes/bitaxe/src/hardware.rs
+++ b/asic-rs-makes/bitaxe/src/hardware.rs
@@ -1,6 +1,7 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::BitaxeModel;
 
@@ -15,7 +16,7 @@ impl From<BitaxeModel> for MinerHardware {
         }
     }
 }
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum BitaxeControlBoard {
     #[serde(rename = "B102")]
     B102,

--- a/asic-rs-makes/bitaxe/src/models.rs
+++ b/asic-rs-makes/bitaxe/src/models.rs
@@ -4,8 +4,9 @@ use asic_rs_core::errors::ModelSelectionError;
 use asic_rs_core::traits::model::MinerModel;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum BitaxeModel {
     #[serde(alias = "BM1368")]
     Supra,

--- a/asic-rs-makes/braiins/Cargo.toml
+++ b/asic-rs-makes/braiins/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 strum.workspace = true
 serde_json.workspace = true
 

--- a/asic-rs-makes/braiins/src/hardware.rs
+++ b/asic-rs-makes/braiins/src/hardware.rs
@@ -1,6 +1,7 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::BraiinsModel;
 
@@ -20,7 +21,7 @@ impl From<BraiinsModel> for MinerHardware {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum BraiinsControlBoard {
     #[serde(rename = "BraiinsCB")]
     BraiinsCB,

--- a/asic-rs-makes/braiins/src/models.rs
+++ b/asic-rs-makes/braiins/src/models.rs
@@ -4,8 +4,9 @@ use asic_rs_core::errors::ModelSelectionError;
 use asic_rs_core::traits::model::MinerModel;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum BraiinsModel {
     #[serde(alias = "BRAIINS MINI MINER BMM 100")]
     BMM100,

--- a/asic-rs-makes/elphapex/Cargo.toml
+++ b/asic-rs-makes/elphapex/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 

--- a/asic-rs-makes/elphapex/src/hardware.rs
+++ b/asic-rs-makes/elphapex/src/hardware.rs
@@ -1,10 +1,11 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::ElphapexModel;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum ElphapexControlBoard {
     DGHome1,
 }

--- a/asic-rs-makes/elphapex/src/models.rs
+++ b/asic-rs-makes/elphapex/src/models.rs
@@ -5,8 +5,9 @@ use asic_rs_core::{
 };
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum ElphapexModel {
     #[serde(alias = "DG1")]
     DG1,

--- a/asic-rs-makes/epic/Cargo.toml
+++ b/asic-rs-makes/epic/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 strum.workspace = true
 serde_json.workspace = true
 

--- a/asic-rs-makes/epic/src/hardware.rs
+++ b/asic-rs-makes/epic/src/hardware.rs
@@ -3,6 +3,7 @@ use asic_rs_core::data::{board::MinerControlBoard, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::EPicModel;
 
@@ -28,7 +29,7 @@ impl From<EPicModel> for MinerHardware {
         }
     }
 }
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum EPicControlBoard {
     #[serde(rename = "ePIC UMC")]
     EPicUMC,

--- a/asic-rs-makes/epic/src/models.rs
+++ b/asic-rs-makes/epic/src/models.rs
@@ -4,8 +4,9 @@ use asic_rs_core::errors::ModelSelectionError;
 use asic_rs_core::traits::model::MinerModel;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum EPicModel {
     #[serde(alias = "BLOCKMINER 520i")]
     BM520i,

--- a/asic-rs-makes/futurebit/Cargo.toml
+++ b/asic-rs-makes/futurebit/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 strum.workspace = true
 serde_json.workspace = true
 

--- a/asic-rs-makes/futurebit/src/hardware.rs
+++ b/asic-rs-makes/futurebit/src/hardware.rs
@@ -1,10 +1,11 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::FutureBitModel;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum FutureBitControlBoard {
     Apollo,
 }

--- a/asic-rs-makes/futurebit/src/models.rs
+++ b/asic-rs-makes/futurebit/src/models.rs
@@ -4,8 +4,9 @@ use asic_rs_core::errors::ModelSelectionError;
 use asic_rs_core::traits::model::MinerModel;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum FutureBitModel {
     #[serde(
         alias = "Apollo",

--- a/asic-rs-makes/marathon/Cargo.toml
+++ b/asic-rs-makes/marathon/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 

--- a/asic-rs-makes/marathon/src/hardware.rs
+++ b/asic-rs-makes/marathon/src/hardware.rs
@@ -1,8 +1,9 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum MarathonControlBoard {
     #[serde(rename = "MaraCB")]
     MaraCB,

--- a/asic-rs-makes/nerdaxe/Cargo.toml
+++ b/asic-rs-makes/nerdaxe/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 strum.workspace = true
 serde_json.workspace = true
 

--- a/asic-rs-makes/nerdaxe/src/hardware.rs
+++ b/asic-rs-makes/nerdaxe/src/hardware.rs
@@ -1,10 +1,11 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::NerdAxeModel;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum NerdAxeControlBoard {
     #[serde(rename = "B102")]
     B102,

--- a/asic-rs-makes/nerdaxe/src/models.rs
+++ b/asic-rs-makes/nerdaxe/src/models.rs
@@ -4,8 +4,9 @@ use asic_rs_core::errors::ModelSelectionError;
 use asic_rs_core::traits::model::MinerModel;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum NerdAxeModel {
     #[serde(alias = "BM1368")]
     NerdAxe,

--- a/asic-rs-makes/proto/Cargo.toml
+++ b/asic-rs-makes/proto/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 strum.workspace = true
 serde_json.workspace = true
 

--- a/asic-rs-makes/proto/src/hardware.rs
+++ b/asic-rs-makes/proto/src/hardware.rs
@@ -1,6 +1,7 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::ProtoModel;
 
@@ -32,7 +33,7 @@ mod tests {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum ProtoControlBoard {
     #[serde(rename = "C1")]
     C1,

--- a/asic-rs-makes/proto/src/models.rs
+++ b/asic-rs-makes/proto/src/models.rs
@@ -4,8 +4,9 @@ use asic_rs_core::errors::ModelSelectionError;
 use asic_rs_core::traits::model::MinerModel;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum ProtoModel {
     #[serde(alias = "RIG")]
     Rig,

--- a/asic-rs-makes/sealminer/Cargo.toml
+++ b/asic-rs-makes/sealminer/Cargo.toml
@@ -9,6 +9,7 @@ description ="Sealminer hardware information for asic-rs"
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 strum.workspace = true
 serde_json.workspace = true
 

--- a/asic-rs-makes/sealminer/src/hardware.rs
+++ b/asic-rs-makes/sealminer/src/hardware.rs
@@ -1,6 +1,7 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::SealMinerModel;
 
@@ -16,7 +17,7 @@ impl From<SealMinerModel> for MinerHardware {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum SealMinerControlBoard {
     #[serde(rename = "TaurusAir")]
     TaurusAir,

--- a/asic-rs-makes/sealminer/src/models.rs
+++ b/asic-rs-makes/sealminer/src/models.rs
@@ -4,8 +4,9 @@ use asic_rs_core::errors::ModelSelectionError;
 use asic_rs_core::traits::model::MinerModel;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum SealMinerModel {
     A2,
     #[strum(to_string = "{0}")]

--- a/asic-rs-makes/volcminer/Cargo.toml
+++ b/asic-rs-makes/volcminer/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 

--- a/asic-rs-makes/volcminer/src/hardware.rs
+++ b/asic-rs-makes/volcminer/src/hardware.rs
@@ -1,10 +1,11 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::VolcMinerModel;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum VolcMinerControlBoard {
     #[serde(rename = "TVXilinx")]
     TVXilinx,

--- a/asic-rs-makes/volcminer/src/models.rs
+++ b/asic-rs-makes/volcminer/src/models.rs
@@ -5,8 +5,9 @@ use asic_rs_core::{
 };
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum VolcMinerModel {
     #[serde(alias = "VOLCMINER D1")]
     D1,

--- a/asic-rs-makes/whatsminer/Cargo.toml
+++ b/asic-rs-makes/whatsminer/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 asic-rs-core.workspace = true
 
 serde.workspace = true
+ts-rs.workspace = true
 strum.workspace = true
 serde_json.workspace = true
 

--- a/asic-rs-makes/whatsminer/src/hardware.rs
+++ b/asic-rs-makes/whatsminer/src/hardware.rs
@@ -1,6 +1,7 @@
 use asic_rs_core::data::{board::MinerControlBoard, collector::FromValue, device::MinerHardware};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
 use crate::models::WhatsMinerModel;
 
@@ -2025,7 +2026,7 @@ impl From<WhatsMinerModel> for MinerHardware {
         }
     }
 }
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum WhatsMinerControlBoard {
     #[serde(rename = "H3")]
     H3,

--- a/asic-rs-makes/whatsminer/src/models.rs
+++ b/asic-rs-makes/whatsminer/src/models.rs
@@ -4,8 +4,9 @@ use asic_rs_core::errors::ModelSelectionError;
 use asic_rs_core::traits::model::MinerModel;
 use serde::{Deserialize, Serialize};
 use strum::Display;
+use ts_rs::TS;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Display, TS)]
 pub enum WhatsMinerModel {
     #[serde(alias = "M20PV10")]
     M20PV10,


### PR DESCRIPTION
## Summary
- Add ts-rs as a workspace dependency and configure large integers as TypeScript numbers.
- Derive TS for shared config, telemetry, model, hardware, pool, message, and make-specific enums.
- Override TypeScript shapes for custom-serialized measurement, MAC, power target, and uptime fields.

## Validation
- cargo fmt
- cargo +1.95.0 check --workspace

Note: cargo check --workspace with the local 1.88.0 override hit an existing compiler limitation in asic-rs-core/src/traits/miner.rs:419, so validation used the already-installed 1.95.0 toolchain.