### PR TITLE
chore: ignore the build artifacts the test scripts generate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,21 @@
 /.git
 CLAUDE.md
 .DS_Store
+
+# Python build and test artifacts.
+#
+# `scripts/run_python_tests.py` runs `maturin develop`, which writes a compiled
+# extension module into python/pyasic_rs/ -- several hundred MB in a debug
+# build, well past GitHub's 100 MB file limit -- and pytest leaves bytecode
+# caches beside the sources. None of it belongs in the tree, and `git add -A`
+# after running the documented test command will otherwise pick all of it up.
+__pycache__/
+*.py[cod]
+*.so
+*.pyd
+*.dylib
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.venv/
+*.egg-info/


### PR DESCRIPTION
`.gitignore` covers `/target` but nothing the Python side produces — even though `scripts/run_python_tests.py` is the documented way to run the suite, and `maturin develop` writes a compiled extension module straight into `python/pyasic_rs/`.

In a debug build that file is **~390 MB**, so `git add -A` after a test run produces a commit GitHub refuses outright at its 100 MB limit. I hit exactly this while working on another branch. pytest and mypy also leave caches beside the sources.

Adds the usual Python patterns:

```
__pycache__/
*.py[cod]
*.so
*.pyd
*.dylib
.pytest_cache/
.mypy_cache/
.ruff_cache/
.venv/
*.egg-info/
```

Nothing matching these is tracked today (`git ls-files` confirms), so this only affects generated output.

**One judgment call left open:** `uv.lock` is produced by the same run and is currently untracked. Lockfiles are often committed deliberately, so I have not ignored it — happy to add it, or to commit the generated one instead, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErTo1a4BgYptp5tC8r1oHR