### PR TITLE
feat(core): name the algorithms this crate's miners actually mine

### DIFF
--- a/asic-rs-core/src/data/device.rs
+++ b/asic-rs-core/src/data/device.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
-use strum::{Display as StrumDisplay, EnumString};
+use strum::{Display as StrumDisplay, EnumIter, EnumString};
 use ts_rs::TS;
 
 use crate::traits::{firmware::MinerFirmware, model::MinerModel};
@@ -88,7 +88,18 @@ impl MinerHardware {
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", derive(asic_rs_pydantic::PyPydanticEnum))]
 #[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, Serialize, Deserialize, StrumDisplay, EnumString, TS,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    StrumDisplay,
+    EnumString,
+    EnumIter,
+    TS,
 )]
 /// Mining hash algorithm.
 pub enum HashAlgorithm {
@@ -112,6 +123,40 @@ pub enum HashAlgorithm {
     #[cfg_attr(feature = "python", pydantic(value = "Kadena"))]
     #[serde(rename = "Kadena")]
     Kadena,
+    /// kHeavyHash mining, as used by Kaspa.
+    #[cfg_attr(feature = "python", pydantic(value = "KHeavyHash"))]
+    #[serde(rename = "KHeavyHash")]
+    KHeavyHash,
+    /// Eaglesong mining, as used by Nervos CKB.
+    #[cfg_attr(feature = "python", pydantic(value = "Eaglesong"))]
+    #[serde(rename = "Eaglesong")]
+    Eaglesong,
+    /// EtHash mining.
+    #[cfg_attr(feature = "python", pydantic(value = "EtHash"))]
+    #[serde(rename = "EtHash")]
+    EtHash,
+    /// Equihash mining, as used by Zcash.
+    #[cfg_attr(feature = "python", pydantic(value = "Equihash"))]
+    #[serde(rename = "Equihash")]
+    Equihash,
+    /// Handshake mining (Blake2b followed by SHA3).
+    #[cfg_attr(feature = "python", pydantic(value = "Handshake"))]
+    #[serde(rename = "Handshake")]
+    Handshake,
+    /// Blake256R14 mining, as used by Decred.
+    #[cfg_attr(feature = "python", pydantic(value = "Blake256R14"))]
+    #[serde(rename = "Blake256R14")]
+    Blake256R14,
+    /// An algorithm this crate cannot name.
+    ///
+    /// Reported when a miner names an algorithm that is not one of the above,
+    /// so that an unrecognised value is not silently presented as SHA-256.
+    /// Note this does not carry the original text: [`HashAlgorithm`] is a
+    /// fieldless enum so that it stays `Copy`, serialises as a plain string,
+    /// and works with the pydantic and TypeScript derives.
+    #[cfg_attr(feature = "python", pydantic(value = "Unknown"))]
+    #[serde(rename = "Unknown")]
+    Unknown,
 }
 
 #[cfg_attr(feature = "python", pymethods)]
@@ -122,5 +167,41 @@ impl HashAlgorithm {
 
     pub fn __str__(&self) -> String {
         self.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use strum::IntoEnumIterator;
+
+    use super::*;
+
+    /// `Display` and `EnumString` are derived independently, so a variant whose
+    /// rendered name does not parse back would be a silent one-way trip.
+    /// Callers resolving an algorithm from a string rely on this holding.
+    #[test]
+    fn every_algorithm_round_trips_through_its_name() {
+        for algo in HashAlgorithm::iter() {
+            let rendered = algo.to_string();
+            assert_eq!(
+                HashAlgorithm::from_str(&rendered).ok(),
+                Some(algo),
+                "{rendered} did not round-trip"
+            );
+        }
+    }
+
+    /// `Unknown` is an explicit value a caller opts into, not a catch-all that
+    /// `from_str` falls back to -- otherwise a typo would parse successfully
+    /// and the round-trip test above would not catch it.
+    #[test]
+    fn unrecognised_names_do_not_parse_as_unknown() {
+        assert!(HashAlgorithm::from_str("NotAnAlgorithm").is_err());
+        assert_eq!(
+            HashAlgorithm::from_str("Unknown").ok(),
+            Some(HashAlgorithm::Unknown)
+        );
     }
 }

--- a/python/pyasic_rs/asic_rs.pyi
+++ b/python/pyasic_rs/asic_rs.pyi
@@ -216,10 +216,17 @@ class FanMode:
 
 @final
 class HashAlgorithm:
+    Blake256R14: Final[HashAlgorithm]
     Blake2S256: Final[HashAlgorithm]
+    Eaglesong: Final[HashAlgorithm]
+    Equihash: Final[HashAlgorithm]
+    EtHash: Final[HashAlgorithm]
+    Handshake: Final[HashAlgorithm]
+    KHeavyHash: Final[HashAlgorithm]
     Kadena: Final[HashAlgorithm]
     SHA256: Final[HashAlgorithm]
     Scrypt: Final[HashAlgorithm]
+    Unknown: Final[HashAlgorithm]
     X11: Final[HashAlgorithm]
     @classmethod
     def __get_pydantic_core_schema__(cls, /, _source_type: "object", _handler: "object") -> "object": ...


### PR DESCRIPTION
First of three, and the foundation for #335.

## Problem

`HashAlgorithm` has five variants, and **three of them — `X11`, `Blake2S256`, `Kadena` — are never constructed anywhere in the tree.** Only `SHA256` and `Scrypt` are ever produced. Meanwhile the AntMiner make alone ships models on ten different algorithms, so anything outside those two had nowhere to go and silently became SHA-256.

## What's needed

I went through every model in every make. Across ~610 models in 13 makes, six algorithms are missing:

| Algorithm | Models |
|---|---|
| kHeavyHash | KS3, KS5, KS5 Pro *(Kaspa)* |
| Eaglesong | K7 *(Nervos CKB)* |
| EtHash | E9 Pro |
| Equihash | Z15, Z15 Pro *(Zcash)* |
| Handshake | HS3 *(Blake2b then SHA3)* |
| Blake256R14 | DR5 *(Decred)* |

Every other make is single-algorithm and already expressible — Elphapex and VolcMiner are Scrypt, the remaining eleven are SHA-256 throughout. AntMiner is the only mixed-algorithm make: 39 SHA-256, 5 Scrypt, 3 X11, and one each of the rest.

## Also adds `Unknown`

For a miner naming an algorithm this crate doesn't recognise. Exactly one backend learns its algorithm from the device at runtime rather than from the model — ePIC, via `/Mining/Algorithm` — and reporting an unrecognised value as SHA-256 would be a confident wrong answer of precisely the kind this type exists to prevent.

`Unknown` is deliberately **not** a `from_str` catch-all: a typo still fails to parse rather than quietly becoming `Unknown`. It's a value a caller opts into.

It carries no payload, so the original text isn't preserved. Doing that would mean a `String` field, which drops `Copy` (relied on at three call sites), serialises as `{"Unknown": "..."}` instead of a flat string, and is rejected outright by `PyPydanticEnum`, which supports only fieldless variants. That's a change to the pydantic macro crate rather than an enum addition, so it's out of scope here — say the word if the fidelity is worth it.

## Tests

`EnumIter` is derived to support a round-trip test asserting `Display` and `EnumString` agree for every variant. They're derived independently, so a variant whose rendered name didn't parse back would be a silent one-way trip — and the next PR in this stack depends on that holding.

## Notes

- `Kadena` and `Blake2S256` are the same algorithm under two names (Kadena *is* Blake2s-256). I have not touched either, since removing a public variant breaks the Python and TypeScript bindings — but worth a decision at some point.
- Stub regenerated with `maturin generate-stubs`, not hand-edited.

Verified: 182 Rust tests pass, `cargo clippy --all-targets` clean under `warnings = "deny"`, `cargo fmt --check` clean, and `cargo check --features python` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErTo1a4BgYptp5tC8r1oHR