### PR TITLE
feat: add S21++

### DIFF
--- a/asic-rs-core/src/data/device.rs
+++ b/asic-rs-core/src/data/device.rs
@@ -237,39 +237,3 @@ mod tests {
         );
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use strum::IntoEnumIterator;
-
-    use super::*;
-
-    /// `Display` and `EnumString` are derived independently, so a variant whose
-    /// rendered name does not parse back would be a silent one-way trip.
-    /// Callers resolving an algorithm from a string rely on this holding.
-    #[test]
-    fn every_algorithm_round_trips_through_its_name() {
-        for algo in HashAlgorithm::iter() {
-            let rendered = algo.to_string();
-            assert_eq!(
-                HashAlgorithm::from_str(&rendered).ok(),
-                Some(algo),
-                "{rendered} did not round-trip"
-            );
-        }
-    }
-
-    /// `Unknown` is an explicit value a caller opts into, not a catch-all that
-    /// `from_str` falls back to -- otherwise a typo would parse successfully
-    /// and the round-trip test above would not catch it.
-    #[test]
-    fn unrecognised_names_do_not_parse_as_unknown() {
-        assert!(HashAlgorithm::from_str("NotAnAlgorithm").is_err());
-        assert_eq!(
-            HashAlgorithm::from_str("Unknown").ok(),
-            Some(HashAlgorithm::Unknown)
-        );
-    }
-}

--- a/asic-rs-makes/antminer/src/hardware.rs
+++ b/asic-rs-makes/antminer/src/hardware.rs
@@ -210,6 +210,10 @@ impl From<AntMinerModel> for MinerHardware {
                 fans: Some(4),
                 boards: Some(vec![Some(55), Some(55), Some(55)]),
             },
+            AntMinerModel::S21PlusPlus => Self {
+                fans: Some(4),
+                boards: Some(vec![Some(55), Some(55), Some(55)]),
+            },
             AntMinerModel::S21PlusHydro => Self {
                 fans: Some(0),
                 boards: Some(vec![Some(95), Some(95), Some(95)]),

--- a/asic-rs-makes/antminer/src/models.rs
+++ b/asic-rs-makes/antminer/src/models.rs
@@ -137,6 +137,8 @@ pub enum AntMinerModel {
     S21XP,
     #[serde(alias = "ANTMINER S21+")]
     S21Plus,
+    #[serde(alias = "ANTMINER S21++")]
+    S21PlusPlus,
     #[serde(alias = "ANTMINER S21 HYD.")]
     #[serde(alias = "ANTMINER S21 HYDRO")]
     S21Hydro,

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -34,7 +34,7 @@ Legend:
 
 ## Exact Supported Models
 
-??? quote "AntMiner (57 models across 23 families)"
+??? quote "AntMiner (58 models across 23 families)"
 
 	??? note "D3 family (1 model)"
 		 - [x] `ANTMINER D3`
@@ -94,7 +94,7 @@ Legend:
 		 - [x] `ANTMINER S19K PRO`
 		 - [x] `ANTMINER S19L`
 		 - [x] `ANTMINER S19PRO+`
-	??? note "S21 family (8 models)"
+	??? note "S21 family (9 models)"
 		 - [x] `ANTMINER S21` (also: `ANTMINER BHB68601`, `ANTMINER BHB68606`)
 		 - [x] `ANTMINER S21 HYD.` (also: `ANTMINER S21 HYDRO`)
 		 - [x] `ANTMINER S21 PRO`
@@ -102,6 +102,7 @@ Legend:
 		 - [x] `ANTMINER S21 XP`
 		 - [x] `ANTMINER S21+`
 		 - [x] `ANTMINER S21+ HYD.` (also: `ANTMINER S21+ HYDRO`)
+		 - [x] `ANTMINER S21++`
 		 - [x] `ANTMINER S21E XP HYD.` (also: `ANTMINER S21E XP HYDRO`)
 	??? note "T9 family (1 model)"
 		 - [x] `ANTMINER T9`


### PR DESCRIPTION
Adds support for an S21++ model i found, 55 chips (same as S21+), and also removes a test that was duplicated.