### PR TITLE
fix(antminer): update stock firmware bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "crc32fast",
+ "digest_auth",
  "diqwest",
  "macaddr",
  "measurements",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ asic-rs-firmwares-volcminer = { path = "asic-rs-firmwares/volcminer", version = 
 asic-rs-firmwares-whatsminer = { path = "asic-rs-firmwares/whatsminer", version = "0.8.0" }
 
 diqwest = "3.2"
+digest_auth = "0.3.1"
 futures = "0.3"
 macaddr = { version = "1.0", features = ["serde_std"] }
 measurements = { version = "0.11", features = ["serde"] }

--- a/asic-rs-firmwares/antminer/Cargo.toml
+++ b/asic-rs-firmwares/antminer/Cargo.toml
@@ -16,6 +16,7 @@ async-trait.workspace = true
 reqwest.workspace = true
 once_cell.workspace = true
 diqwest.workspace = true
+digest_auth.workspace = true
 serde_json.workspace = true
 semver.workspace = true
 chrono.workspace = true

--- a/asic-rs-firmwares/antminer/src/backends/v2020/firmware.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2020/firmware.rs
@@ -218,26 +218,31 @@ fn candidate_score(entry: &BmuEntry, miner: &MinerTypeInfo) -> Option<u8> {
     let miner_model = normalized(&miner.model);
     let miner_subtype = normalized(&miner.subtype);
 
+    let subtype_matches = !miner_subtype.is_empty()
+        && (hardware == miner_subtype
+            || chip == miner_subtype
+            || wildcard_compatible(&entry.hardware, &miner.subtype)
+            || wildcard_compatible(&entry.chip, &miner.subtype));
+
     if model != miner_model {
-        return None;
+        // Some stock releases report a generic control-board model (for example,
+        // "Antminer BHB42XXX") instead of the product name stored in the BMU. Only fall back
+        // to a different product label when the control-board subtype is a strong match.
+        return subtype_matches.then_some(4);
     }
 
     if miner_subtype.is_empty() {
-        Some(1)
-    } else if hardware == miner_subtype
-        || chip == miner_subtype
-        || wildcard_compatible(&entry.hardware, &miner.subtype)
-        || wildcard_compatible(&entry.chip, &miner.subtype)
-    {
-        Some(4)
+        Some(5)
+    } else if subtype_matches {
+        Some(8)
     } else if hardware.contains(&miner_subtype) || chip.contains(&miner_subtype) {
-        Some(3)
+        Some(7)
     } else if filename.contains(&miner_subtype) {
-        Some(2)
+        Some(6)
     } else if !hardware.is_empty() || !chip.is_empty() || filename.contains("ctrl") {
         None
     } else {
-        Some(1)
+        Some(5)
     }
 }
 
@@ -404,6 +409,38 @@ mod tests {
                 .unwrap();
 
         assert_eq!(resolved.filename, "s21-hyd.bin");
+        assert_eq!(resolved.bytes, b"right");
+    }
+
+    #[tokio::test]
+    async fn bmu_uses_exact_subtype_when_miner_reports_generic_model() {
+        let bmu = build_bmu(&[
+            (
+                "s19j-pro-zynq.bmu",
+                "Zynq7007",
+                "Ctrl_BHB42XXX",
+                "Antminer S19j Pro",
+                b"wrong".as_slice(),
+            ),
+            (
+                "s19j-pro-amlogic.bmu",
+                "AMLogic",
+                "AMLCtrl_BHB42XXX",
+                "Antminer S19j Pro",
+                b"right".as_slice(),
+            ),
+        ]);
+        let miner = MinerTypeInfo {
+            model: "Antminer BHB42XXX".to_string(),
+            subtype: "AMLCtrl_BHB42XXX".to_string(),
+        };
+
+        let resolved =
+            resolve_firmware_image(FirmwareImage::new("bundle.bmu".to_string(), bmu), &miner)
+                .await
+                .unwrap();
+
+        assert_eq!(resolved.filename, "s19j-pro-amlogic.bmu");
         assert_eq!(resolved.bytes, b"right");
     }
 

--- a/asic-rs-firmwares/antminer/src/backends/v2020/web.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2020/web.rs
@@ -6,8 +6,13 @@ use anyhow::{Context, Result, anyhow, bail};
 use asic_rs_core::data::firmware::FirmwareImage;
 use asic_rs_core::{data::command::MinerCommand, traits::miner::*};
 use async_trait::async_trait;
+use digest_auth::{AuthContext, HttpMethod};
 use diqwest::WithDigestAuth;
-use reqwest::{Client, Method, Response, multipart};
+use reqwest::{
+    Client, Method, Response, StatusCode,
+    header::{AUTHORIZATION, HeaderValue, WWW_AUTHENTICATE},
+    multipart,
+};
 use serde_json::{Value, json};
 
 use super::firmware::AntMinerFirmwareUpgradeResponseExt;
@@ -41,6 +46,54 @@ impl AntMinerWebAPI {
             .mime_str("application/octet-stream")
             .context("failed to set firmware part mime type")?;
         Ok(multipart::Form::new().part("firmware", part))
+    }
+
+    fn build_firmware_upload_authorization(&self, challenge: &str) -> Result<HeaderValue> {
+        let context = AuthContext::new_with_method(
+            self.auth.username(),
+            self.auth.password(),
+            "/cgi-bin/upgrade.cgi",
+            None::<&[u8]>,
+            HttpMethod::POST,
+        );
+        let authorization = digest_auth::parse(challenge)
+            .context("failed to parse firmware upload digest challenge")?
+            .respond(&context)
+            .context("failed to answer firmware upload digest challenge")?;
+
+        HeaderValue::from_str(&authorization.to_header_string())
+            .context("failed to encode firmware upload authorization header")
+    }
+
+    async fn firmware_upload_authorization(&self) -> Result<Option<HeaderValue>> {
+        let url = format!("http://{}:{}/cgi-bin/upgrade.cgi", self.ip, self.port);
+        let response = self
+            .client()?
+            .get(url)
+            .timeout(self.timeout)
+            .send()
+            .await
+            .context("failed to request firmware upload digest challenge")?;
+
+        if response.status().is_success() {
+            return Ok(None);
+        }
+        if response.status() != StatusCode::UNAUTHORIZED {
+            bail!(
+                "firmware upload digest challenge failed with status code {}",
+                response.status()
+            );
+        }
+
+        let challenge = response
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .context("firmware upload digest challenge response is missing WWW-Authenticate")?
+            .to_str()
+            .context("firmware upload digest challenge is not valid text")?;
+
+        self.build_firmware_upload_authorization(challenge)
+            .map(Some)
     }
 
     pub fn new(ip: IpAddr, auth: MinerAuth) -> Self {
@@ -242,13 +295,21 @@ impl AntMinerWebAPI {
     pub async fn upgrade_firmware(&self, image: FirmwareImage) -> Result<()> {
         let url = format!("http://{}:{}/cgi-bin/upgrade.cgi", self.ip, self.port);
         let form = Self::build_firmware_upload_form(image)?;
+        let authorization = self.firmware_upload_authorization().await?;
 
-        let response = self
+        let mut request = self
             .client()?
             .post(url)
             .multipart(form)
-            .timeout(self.timeout.max(Duration::from_secs(60)))
-            .send_digest_auth((self.auth.username(), self.auth.password()))
+            .timeout(self.timeout.max(Duration::from_secs(60)));
+        if let Some(authorization) = authorization {
+            request = request.header(AUTHORIZATION, authorization);
+        }
+
+        // Multipart bodies are streams and cannot be cloned by diqwest's challenge/response
+        // flow. Authenticate the single upload request with the challenge obtained above.
+        let response = request
+            .send()
             .await
             .with_context(|| "firmware upload HTTP request failed".to_string())?;
 
@@ -342,5 +403,29 @@ impl WebAPIClient for AntMinerWebAPI {
     ) -> Result<Value> {
         self.send_web_command(command, privileged, parameters, method)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_digest_authorization_for_firmware_upload_endpoint() {
+        let web = AntMinerWebAPI::new(
+            "127.0.0.1".parse().unwrap(),
+            MinerAuth::new("root", "secret"),
+        );
+        let authorization = web
+            .build_firmware_upload_authorization(
+                r#"Digest realm="antMiner Configuration", nonce="0123456789", qop="auth""#,
+            )
+            .unwrap();
+        let authorization = authorization.to_str().unwrap();
+
+        assert!(authorization.starts_with("Digest "));
+        assert!(authorization.contains(r#"username="root""#));
+        assert!(authorization.contains(r#"uri="/cgi-bin/upgrade.cgi""#));
+        assert!(authorization.contains("qop=auth"));
     }
 }

--- a/asic-rs-firmwares/antminer/src/backends/v2023_07/firmware.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2023_07/firmware.rs
@@ -218,26 +218,31 @@ fn candidate_score(entry: &BmuEntry, miner: &MinerTypeInfo) -> Option<u8> {
     let miner_model = normalized(&miner.model);
     let miner_subtype = normalized(&miner.subtype);
 
+    let subtype_matches = !miner_subtype.is_empty()
+        && (hardware == miner_subtype
+            || chip == miner_subtype
+            || wildcard_compatible(&entry.hardware, &miner.subtype)
+            || wildcard_compatible(&entry.chip, &miner.subtype));
+
     if model != miner_model {
-        return None;
+        // Some stock releases report a generic control-board model (for example,
+        // "Antminer BHB42XXX") instead of the product name stored in the BMU. Only fall back
+        // to a different product label when the control-board subtype is a strong match.
+        return subtype_matches.then_some(4);
     }
 
     if miner_subtype.is_empty() {
-        Some(1)
-    } else if hardware == miner_subtype
-        || chip == miner_subtype
-        || wildcard_compatible(&entry.hardware, &miner.subtype)
-        || wildcard_compatible(&entry.chip, &miner.subtype)
-    {
-        Some(4)
+        Some(5)
+    } else if subtype_matches {
+        Some(8)
     } else if hardware.contains(&miner_subtype) || chip.contains(&miner_subtype) {
-        Some(3)
+        Some(7)
     } else if filename.contains(&miner_subtype) {
-        Some(2)
+        Some(6)
     } else if !hardware.is_empty() || !chip.is_empty() || filename.contains("ctrl") {
         None
     } else {
-        Some(1)
+        Some(5)
     }
 }
 
@@ -404,6 +409,38 @@ mod tests {
                 .unwrap();
 
         assert_eq!(resolved.filename, "s21-hyd.bin");
+        assert_eq!(resolved.bytes, b"right");
+    }
+
+    #[tokio::test]
+    async fn bmu_uses_exact_subtype_when_miner_reports_generic_model() {
+        let bmu = build_bmu(&[
+            (
+                "s19j-pro-zynq.bmu",
+                "Zynq7007",
+                "Ctrl_BHB42XXX",
+                "Antminer S19j Pro",
+                b"wrong".as_slice(),
+            ),
+            (
+                "s19j-pro-amlogic.bmu",
+                "AMLogic",
+                "AMLCtrl_BHB42XXX",
+                "Antminer S19j Pro",
+                b"right".as_slice(),
+            ),
+        ]);
+        let miner = MinerTypeInfo {
+            model: "Antminer BHB42XXX".to_string(),
+            subtype: "AMLCtrl_BHB42XXX".to_string(),
+        };
+
+        let resolved =
+            resolve_firmware_image(FirmwareImage::new("bundle.bmu".to_string(), bmu), &miner)
+                .await
+                .unwrap();
+
+        assert_eq!(resolved.filename, "s19j-pro-amlogic.bmu");
         assert_eq!(resolved.bytes, b"right");
     }
 

--- a/asic-rs-firmwares/antminer/src/backends/v2023_07/web.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2023_07/web.rs
@@ -6,8 +6,13 @@ use anyhow::{Context, Result, anyhow, bail};
 use asic_rs_core::data::firmware::FirmwareImage;
 use asic_rs_core::{data::command::MinerCommand, traits::miner::*};
 use async_trait::async_trait;
+use digest_auth::{AuthContext, HttpMethod};
 use diqwest::WithDigestAuth;
-use reqwest::{Client, Method, Response, multipart};
+use reqwest::{
+    Client, Method, Response, StatusCode,
+    header::{AUTHORIZATION, HeaderValue, WWW_AUTHENTICATE},
+    multipart,
+};
 use serde_json::{Value, json};
 
 use super::firmware::AntMinerFirmwareUpgradeResponseExt;
@@ -41,6 +46,54 @@ impl AntMinerWebAPI {
             .mime_str("application/octet-stream")
             .context("failed to set firmware part mime type")?;
         Ok(multipart::Form::new().part("firmware", part))
+    }
+
+    fn build_firmware_upload_authorization(&self, challenge: &str) -> Result<HeaderValue> {
+        let context = AuthContext::new_with_method(
+            self.auth.username(),
+            self.auth.password(),
+            "/cgi-bin/upgrade.cgi",
+            None::<&[u8]>,
+            HttpMethod::POST,
+        );
+        let authorization = digest_auth::parse(challenge)
+            .context("failed to parse firmware upload digest challenge")?
+            .respond(&context)
+            .context("failed to answer firmware upload digest challenge")?;
+
+        HeaderValue::from_str(&authorization.to_header_string())
+            .context("failed to encode firmware upload authorization header")
+    }
+
+    async fn firmware_upload_authorization(&self) -> Result<Option<HeaderValue>> {
+        let url = format!("http://{}:{}/cgi-bin/upgrade.cgi", self.ip, self.port);
+        let response = self
+            .client()?
+            .get(url)
+            .timeout(self.timeout)
+            .send()
+            .await
+            .context("failed to request firmware upload digest challenge")?;
+
+        if response.status().is_success() {
+            return Ok(None);
+        }
+        if response.status() != StatusCode::UNAUTHORIZED {
+            bail!(
+                "firmware upload digest challenge failed with status code {}",
+                response.status()
+            );
+        }
+
+        let challenge = response
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .context("firmware upload digest challenge response is missing WWW-Authenticate")?
+            .to_str()
+            .context("firmware upload digest challenge is not valid text")?;
+
+        self.build_firmware_upload_authorization(challenge)
+            .map(Some)
     }
 
     pub fn new(ip: IpAddr, auth: MinerAuth) -> Self {
@@ -242,13 +295,21 @@ impl AntMinerWebAPI {
     pub async fn upgrade_firmware(&self, image: FirmwareImage) -> Result<()> {
         let url = format!("http://{}:{}/cgi-bin/upgrade.cgi", self.ip, self.port);
         let form = Self::build_firmware_upload_form(image)?;
+        let authorization = self.firmware_upload_authorization().await?;
 
-        let response = self
+        let mut request = self
             .client()?
             .post(url)
             .multipart(form)
-            .timeout(self.timeout.max(Duration::from_secs(60)))
-            .send_digest_auth((self.auth.username(), self.auth.password()))
+            .timeout(self.timeout.max(Duration::from_secs(60)));
+        if let Some(authorization) = authorization {
+            request = request.header(AUTHORIZATION, authorization);
+        }
+
+        // Multipart bodies are streams and cannot be cloned by diqwest's challenge/response
+        // flow. Authenticate the single upload request with the challenge obtained above.
+        let response = request
+            .send()
             .await
             .with_context(|| "firmware upload HTTP request failed".to_string())?;
 
@@ -342,5 +403,29 @@ impl WebAPIClient for AntMinerWebAPI {
     ) -> Result<Value> {
         self.send_web_command(command, privileged, parameters, method)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_digest_authorization_for_firmware_upload_endpoint() {
+        let web = AntMinerWebAPI::new(
+            "127.0.0.1".parse().unwrap(),
+            MinerAuth::new("root", "secret"),
+        );
+        let authorization = web
+            .build_firmware_upload_authorization(
+                r#"Digest realm="antMiner Configuration", nonce="0123456789", qop="auth""#,
+            )
+            .unwrap();
+        let authorization = authorization.to_str().unwrap();
+
+        assert!(authorization.starts_with("Digest "));
+        assert!(authorization.contains(r#"username="root""#));
+        assert!(authorization.contains(r#"uri="/cgi-bin/upgrade.cgi""#));
+        assert!(authorization.contains("qop=auth"));
     }
 }


### PR DESCRIPTION
## Summary

- fetch a Digest challenge before starting an Antminer firmware upload
- authorize the streaming multipart request directly instead of passing it through the diqwest clone-based challenge flow
- allow an exact control-board subtype match when older stock firmware reports a generic miner model
- cover both v2020 and v2023_07 Antminer backends
- add regression coverage for upload authorization and generic-model BMU selection

## Root causes

Reqwest represents multipart bodies as streams, so their request builders are not cloneable. send_digest_auth clones the request builder before sending its initial request, causing every firmware upload to fail before any bytes reach the miner.

Some older stock firmware reports a generic miner_type such as Antminer BHB42XXX while its official BMU bundle identifies the product as Antminer S19j Pro. The resolver previously rejected the bundle before considering the exact AMLCtrl_BHB42XXX subtype match.

## Validation

- cargo +1.95.0 test --package asic-rs-firmwares-antminer --lib
- cargo +1.95.0 clippy --package asic-rs-firmwares-antminer --all-targets -- -D warnings
