### PR TITLE
fix(factory): bound miner discovery operations

### DIFF
--- a/asic-rs-core/src/util.rs
+++ b/asic-rs-core/src/util.rs
@@ -26,8 +26,18 @@ pub fn unix_timestamp_secs() -> u64 {
     )
 }
 
+/// Build an HTTP client with bounded connection and total-request deadlines
+/// for firmware discovery.
 pub fn build_discovery_client() -> Result<reqwest::Client, ModelSelectionError> {
+    build_discovery_client_with_timeout(DEFAULT_RPC_TIMEOUT)
+}
+
+fn build_discovery_client_with_timeout(
+    timeout: Duration,
+) -> Result<reqwest::Client, ModelSelectionError> {
     reqwest::Client::builder()
+        .connect_timeout(timeout)
+        .timeout(timeout)
         .pool_max_idle_per_host(0)
         .build()
         .map_err(|_| ModelSelectionError::NoModelResponse)
@@ -47,6 +57,7 @@ static HTTP_CLIENT: LazyLock<Result<reqwest::Client, reqwest::Error>> = LazyLock
         .redirect(reqwest::redirect::Policy::none())
         .danger_accept_invalid_certs(true)
         .gzip(true)
+        .connect_timeout(DEFAULT_RPC_TIMEOUT)
         .timeout(DEFAULT_RPC_TIMEOUT)
         .pool_max_idle_per_host(0)
         .build()
@@ -242,7 +253,27 @@ fn parse_rpc_result(response: &str) -> Option<serde_json::Value> {
 mod tests {
     use super::*;
     use crate::errors::RPCError;
-    use tokio::io::AsyncWriteExt;
+    use tokio::{io::AsyncWriteExt, net::TcpListener};
+
+    #[tokio::test]
+    async fn discovery_http_client_times_out_on_stalled_response() -> anyhow::Result<()> {
+        let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).await?;
+        let address = listener.local_addr()?;
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await?;
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            std::io::Result::Ok(())
+        });
+        let client = build_discovery_client_with_timeout(Duration::from_millis(50))?;
+        let started = tokio::time::Instant::now();
+
+        let response = client.get(format!("http://{address}")).send().await;
+
+        assert!(response.is_err_and(|error| error.is_timeout()));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        server.abort();
+        Ok(())
+    }
 
     #[tokio::test]
     async fn null_terminated_response() {

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,9 @@ differences.
 ## Discovery
 
 `MinerFactory` owns the scan range and discovery tuning.
+The identification timeout is an end-to-end deadline covering discovery
+commands and firmware-specific miner construction. Discovery HTTP clients also
+apply explicit connection and total-request deadlines.
 
 === "Rust"
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -305,17 +305,22 @@ impl MinerFactory {
     /// overridden via [`Self::with_firmware_discovery_auth`].
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn get_miner(&self, ip: IpAddr) -> Result<Option<Box<dyn Miner>>> {
-        match AssertUnwindSafe(self.get_miner_inner(ip))
-            .catch_unwind()
-            .await
-        {
-            Ok(result) => result,
-            Err(panic_info) => {
+        let discovery = AssertUnwindSafe(self.get_miner_inner(ip)).catch_unwind();
+        match timeout(self.identification_timeout, discovery).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(panic_info)) => {
                 let msg = panic_message(&*panic_info);
                 tracing::error!("panic during miner discovery for {ip}: {msg}");
                 Err(anyhow::anyhow!(
                     "internal panic during miner discovery: {msg}"
                 ))
+            }
+            Err(_) => {
+                tracing::debug!(
+                    timeout_ms = self.identification_timeout.as_millis(),
+                    "miner discovery timed out for {ip}"
+                );
+                Ok(None)
             }
         }
     }
@@ -342,23 +347,15 @@ impl MinerFactory {
                 discovery_tasks.push(get_miner_type_from_command_catch_unwind(ip, command, reg));
             }
 
-            let id_timeout = tokio::time::sleep(self.identification_timeout).fuse();
-            pin_mut!(id_timeout);
-
             let mut found: Option<Arc<dyn FirmwareEntry>> = None;
 
             loop {
                 if discovery_tasks.is_empty() {
                     break;
                 }
-                tokio::select! {
-                    _ = &mut id_timeout => break,
-                    r = discovery_tasks.next() => {
-                        if let Some(Some(fw)) = r {
-                            found = Some(fw);
-                            break;
-                        }
-                    }
+                if let Some(Some(fw)) = discovery_tasks.next().await {
+                    found = Some(fw);
+                    break;
                 }
             }
 
@@ -372,7 +369,6 @@ impl MinerFactory {
                         break;
                     }
                     tokio::select! {
-                        _ = &mut id_timeout => break,
                         _ = &mut upgrade_window => break,
                         r = discovery_tasks.next() => {
                             if let Some(Some(fw)) = r
@@ -490,13 +486,16 @@ impl MinerFactory {
         }
     }
 
-    /// Set the maximum time spent identifying a miner once connectivity exists.
+    /// Set the maximum time spent identifying and constructing a miner.
+    ///
+    /// The deadline covers all discovery commands and firmware-specific miner
+    /// construction after connectivity has been established.
     pub fn with_identification_timeout(mut self, timeout: Duration) -> Self {
         self.identification_timeout = timeout;
         self
     }
 
-    /// Set the identification timeout in seconds.
+    /// Set the end-to-end identification and construction timeout in seconds.
     pub fn with_identification_timeout_secs(mut self, timeout_secs: u64) -> Self {
         self.identification_timeout = Duration::from_secs(timeout_secs);
         self
@@ -876,6 +875,47 @@ fn generate_ips_from_ranges(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    #[cfg(feature = "whatsminer")]
+    async fn identification_timeout_bounds_miner_construction() -> anyhow::Result<()> {
+        use asic_rs_firmwares_whatsminer::firmware::WhatsMinerFirmware;
+        use tokio::{
+            io::{AsyncReadExt, AsyncWriteExt},
+            net::TcpListener,
+            sync::oneshot,
+        };
+
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 4028)).await?;
+        let (construction_started, mut construction_started_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut identification_socket, _) = listener.accept().await?;
+            let mut request = [0_u8; 256];
+            let _bytes_read = identification_socket.read(&mut request).await?;
+            identification_socket
+                .write_all(
+                    b"{\"STATUS\":[{\"STATUS\":\"S\"}],\"DEVDETAILS\":[{\"Driver\":\"bitmicro\"}]}\0",
+                )
+                .await?;
+
+            let (_construction_socket, _) = listener.accept().await?;
+            let _ = construction_started.send(());
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            std::io::Result::Ok(())
+        });
+        let factory = MinerFactory::new()
+            .with_firmwares(vec![Arc::new(WhatsMinerFirmware::default())])
+            .with_identification_timeout(Duration::from_millis(250));
+        let started = tokio::time::Instant::now();
+
+        let miner = factory.get_miner(IpAddr::V4(Ipv4Addr::LOCALHOST)).await?;
+
+        assert!(miner.is_none());
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(construction_started_rx.try_recv().is_ok());
+        server.abort();
+        Ok(())
+    }
 
     #[test]
     #[cfg(feature = "whatsminer")]

--- a/src/python/factory.rs
+++ b/src/python/factory.rs
@@ -332,7 +332,7 @@ impl MinerFactory {
         }))
     }
 
-    /// Set the maximum seconds spent identifying a miner after it responds.
+    /// Set the maximum seconds spent identifying and constructing a miner.
     pub fn with_identification_timeout_secs<'py>(
         slf: PyRefMut<'py, Self>,
         timeout_secs: u64,


### PR DESCRIPTION
Added timeouts to discovery ops. The first of a few PRs I'm going to submit for scan improvements. Contributes to #319 
---
This change prevents miner discovery from hanging indefinitely.

  Previously, the identification timeout covered only the firmware-detection commands. Once firmware was identified,
  constructing the miner object could perform additional network requests without being covered by that deadline. HTTP
  connections also lacked an explicit connection timeout in some paths.

  The change:

  - Applies the existing identification timeout to the entire operation:
      - Run firmware-detection commands.
      - Select the detected firmware.
      - Construct the firmware-specific miner object.

  - Adds explicit connection and total-request deadlines to discovery HTTP clients.
  - Treats an expired discovery deadline as “miner not identified” (Ok(None)), allowing the rest of the scan to continue.
  - Adds tests for a stalled HTTP response and stalled miner construction.
  - Updates Rust/Python documentation to clarify the timeout’s end-to-end meaning.

  It deliberately does not change concurrency, retry behavior, port probing, scan staging, or defaults. Consequently, normal
  scans perform essentially the same; the benefit appears when a device or connection stalls.