### PR TITLE
refactor(firmware): centralize firmware display names

### DIFF
--- a/asic-rs-core/src/data/device.rs
+++ b/asic-rs-core/src/data/device.rs
@@ -37,6 +37,90 @@ impl DeviceInfo {
 }
 
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
+#[cfg_attr(feature = "python", derive(asic_rs_pydantic::PyPydanticEnum))]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    StrumDisplay,
+    EnumString,
+    EnumIter,
+    TS,
+)]
+/// Miner firmware name or family.
+pub enum FirmwareType {
+    #[cfg_attr(feature = "python", pydantic(value = "AntMiner Stock"))]
+    #[serde(rename = "AntMiner Stock")]
+    #[strum(serialize = "AntMiner Stock")]
+    AntMinerStock,
+    #[cfg_attr(feature = "python", pydantic(value = "Auradine Stock"))]
+    #[serde(rename = "Auradine Stock")]
+    #[strum(serialize = "Auradine Stock")]
+    AuradineStock,
+    #[cfg_attr(feature = "python", pydantic(value = "AvalonMiner Stock"))]
+    #[serde(rename = "AvalonMiner Stock")]
+    #[strum(serialize = "AvalonMiner Stock")]
+    AvalonMinerStock,
+    #[cfg_attr(feature = "python", pydantic(value = "Bitaxe Stock"))]
+    #[serde(rename = "Bitaxe Stock")]
+    #[strum(serialize = "Bitaxe Stock")]
+    BitaxeStock,
+    #[cfg_attr(feature = "python", pydantic(value = "Braiins"))]
+    #[serde(rename = "Braiins")]
+    #[strum(serialize = "Braiins")]
+    Braiins,
+    #[cfg_attr(feature = "python", pydantic(value = "Elphapex Stock"))]
+    #[serde(rename = "Elphapex Stock")]
+    #[strum(serialize = "Elphapex Stock")]
+    ElphapexStock,
+    #[cfg_attr(feature = "python", pydantic(value = "FutureBit Stock"))]
+    #[serde(rename = "FutureBit Stock")]
+    #[strum(serialize = "FutureBit Stock")]
+    FutureBitStock,
+    #[cfg_attr(feature = "python", pydantic(value = "LuxOS"))]
+    #[serde(rename = "LuxOS")]
+    #[strum(serialize = "LuxOS")]
+    LuxOS,
+    #[cfg_attr(feature = "python", pydantic(value = "Marathon"))]
+    #[serde(rename = "Marathon")]
+    #[strum(serialize = "Marathon")]
+    Marathon,
+    #[cfg_attr(feature = "python", pydantic(value = "Nerdaxe Stock"))]
+    #[serde(rename = "Nerdaxe Stock")]
+    #[strum(serialize = "Nerdaxe Stock")]
+    NerdaxeStock,
+    #[cfg_attr(feature = "python", pydantic(value = "Proto Stock"))]
+    #[serde(rename = "Proto Stock")]
+    #[strum(serialize = "Proto Stock")]
+    ProtoStock,
+    #[cfg_attr(feature = "python", pydantic(value = "SealMiner Stock"))]
+    #[serde(rename = "SealMiner Stock")]
+    #[strum(serialize = "SealMiner Stock")]
+    SealMinerStock,
+    #[cfg_attr(feature = "python", pydantic(value = "UMC OS"))]
+    #[serde(rename = "UMC OS")]
+    #[strum(serialize = "UMC OS")]
+    UmcOS,
+    #[cfg_attr(feature = "python", pydantic(value = "VNish"))]
+    #[serde(rename = "VNish")]
+    #[strum(serialize = "VNish")]
+    VNish,
+    #[cfg_attr(feature = "python", pydantic(value = "VolcMiner Stock"))]
+    #[serde(rename = "VolcMiner Stock")]
+    #[strum(serialize = "VolcMiner Stock")]
+    VolcMinerStock,
+    #[cfg_attr(feature = "python", pydantic(value = "WhatsMiner Stock"))]
+    #[serde(rename = "WhatsMiner Stock")]
+    #[strum(serialize = "WhatsMiner Stock")]
+    WhatsMinerStock,
+}
+
+#[cfg_attr(feature = "python", pyclass(from_py_object, module = "asic_rs"))]
 #[cfg_attr(feature = "python", asic_rs_pydantic::py_pydantic_model(getters))]
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Default, TS)]
 /// Expected hardware counts for a miner model.

--- a/asic-rs-firmwares/antminer/src/backends/v2020/mod.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2020/mod.rs
@@ -14,7 +14,7 @@ use asic_rs_core::{
             DataCollector, DataExtensions, DataExtractor, DataField, DataLocation, get_by_pointer,
         },
         command::MinerCommand,
-        device::DeviceInfo,
+        device::{DeviceInfo, FirmwareType},
         fan::FanData,
         firmware::FirmwareImage,
         hashrate::{HashRate, HashRateUnit},
@@ -1258,15 +1258,18 @@ impl SupportsTuningConfig for AntMinerV2020 {
             TuningTarget::MiningMode(MiningMode::Low) => MinerMode::Low,
             TuningTarget::MiningMode(MiningMode::Normal) => MinerMode::Normal,
             TuningTarget::MiningMode(MiningMode::High) => MinerMode::High,
-            TuningTarget::Power(_) => {
-                anyhow::bail!("Power tuning target is not supported on Antminer stock firmware")
-            }
-            TuningTarget::HashRate(_) => {
-                anyhow::bail!("Hashrate tuning target is not supported on Antminer stock firmware")
-            }
-            TuningTarget::Preset(_) => {
-                anyhow::bail!("Preset tuning target is not supported on Antminer stock firmware")
-            }
+            TuningTarget::Power(_) => anyhow::bail!(
+                "Power tuning target is not supported on {} firmware",
+                FirmwareType::AntMinerStock
+            ),
+            TuningTarget::HashRate(_) => anyhow::bail!(
+                "Hashrate tuning target is not supported on {} firmware",
+                FirmwareType::AntMinerStock
+            ),
+            TuningTarget::Preset(_) => anyhow::bail!(
+                "Preset tuning target is not supported on {} firmware",
+                FirmwareType::AntMinerStock
+            ),
         };
 
         let pre = self.web.get_miner_conf().await?;

--- a/asic-rs-firmwares/antminer/src/backends/v2023_07/mod.rs
+++ b/asic-rs-firmwares/antminer/src/backends/v2023_07/mod.rs
@@ -16,7 +16,7 @@ use asic_rs_core::{
             DataCollector, DataExtensions, DataExtractor, DataField, DataLocation, get_by_pointer,
         },
         command::MinerCommand,
-        device::DeviceInfo,
+        device::{DeviceInfo, FirmwareType},
         fan::FanData,
         firmware::FirmwareImage,
         hashrate::{HashRate, HashRateUnit},
@@ -1237,15 +1237,18 @@ impl SupportsTuningConfig for AntMinerV202307 {
             TuningTarget::MiningMode(MiningMode::Low) => MinerMode::Low,
             TuningTarget::MiningMode(MiningMode::Normal) => MinerMode::Normal,
             TuningTarget::MiningMode(MiningMode::High) => MinerMode::High,
-            TuningTarget::Power(_) => {
-                anyhow::bail!("Power tuning target is not supported on Antminer stock firmware")
-            }
-            TuningTarget::HashRate(_) => {
-                anyhow::bail!("Hashrate tuning target is not supported on Antminer stock firmware")
-            }
-            TuningTarget::Preset(_) => {
-                anyhow::bail!("Preset tuning target is not supported on Antminer stock firmware")
-            }
+            TuningTarget::Power(_) => anyhow::bail!(
+                "Power tuning target is not supported on {} firmware",
+                FirmwareType::AntMinerStock
+            ),
+            TuningTarget::HashRate(_) => anyhow::bail!(
+                "Hashrate tuning target is not supported on {} firmware",
+                FirmwareType::AntMinerStock
+            ),
+            TuningTarget::Preset(_) => anyhow::bail!(
+                "Preset tuning target is not supported on {} firmware",
+                FirmwareType::AntMinerStock
+            ),
         };
 
         let pre = self.web.get_miner_conf().await?;

--- a/asic-rs-firmwares/antminer/src/firmware.rs
+++ b/asic-rs-firmwares/antminer/src/firmware.rs
@@ -1,6 +1,6 @@
 use std::{fmt, fmt::Display, net::IpAddr};
 
-use asic_rs_core::data::device::{HashAlgorithm, MinerHardware};
+use asic_rs_core::data::device::{FirmwareType, HashAlgorithm, MinerHardware};
 use asic_rs_core::traits::model::{MinerModelAlgorithm, UnknownMinerModel};
 use asic_rs_core::{
     data::command::MinerCommand,
@@ -78,7 +78,7 @@ pub struct AntMinerStockFirmware {}
 
 impl Display for AntMinerStockFirmware {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "AntMiner Stock")
+        write!(f, "{}", FirmwareType::AntMinerStock)
     }
 }
 

--- a/asic-rs-firmwares/auradine/src/firmware.rs
+++ b/asic-rs-firmwares/auradine/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::{RPC_DEVDETAILS, RPC_VERSION},
     errors::ModelSelectionError,
     traits::{
@@ -23,7 +23,7 @@ pub struct AuradineFirmware {}
 
 impl Display for AuradineFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Auradine Stock")
+        write!(f, "{}", FirmwareType::AuradineStock)
     }
 }
 

--- a/asic-rs-firmwares/avalonminer/src/firmware.rs
+++ b/asic-rs-firmwares/avalonminer/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::{HTTP_WEB_ROOT, RPC_VERSION},
     errors::ModelSelectionError,
     traits::{
@@ -23,7 +23,7 @@ pub struct AvalonStockFirmware {}
 
 impl Display for AvalonStockFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "AvalonMiner Stock")
+        write!(f, "{}", FirmwareType::AvalonMinerStock)
     }
 }
 impl DiscoveryCommands for AvalonStockFirmware {

--- a/asic-rs-firmwares/bitaxe/src/firmware.rs
+++ b/asic-rs-firmwares/bitaxe/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::HTTP_WEB_ROOT,
     errors::ModelSelectionError,
     traits::{
@@ -23,7 +23,7 @@ pub struct BitaxeFirmware {}
 
 impl Display for BitaxeFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Bitaxe Stock")
+        write!(f, "{}", FirmwareType::BitaxeStock)
     }
 }
 

--- a/asic-rs-firmwares/braiins/src/firmware.rs
+++ b/asic-rs-firmwares/braiins/src/firmware.rs
@@ -4,7 +4,7 @@ use asic_rs_core::traits::model::MinerModelAlgorithm;
 use asic_rs_core::{
     data::{
         command::MinerCommand,
-        device::{HashAlgorithm, MinerHardware},
+        device::{FirmwareType, HashAlgorithm, MinerHardware},
     },
     discovery::{HTTP_WEB_ROOT, RPC_VERSION},
     errors::ModelSelectionError,
@@ -82,7 +82,7 @@ pub struct BraiinsFirmware {}
 
 impl Display for BraiinsFirmware {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Braiins")
+        write!(f, "{}", FirmwareType::Braiins)
     }
 }
 

--- a/asic-rs-firmwares/elphapex/src/firmware.rs
+++ b/asic-rs-firmwares/elphapex/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::HTTP_WEB_ROOT,
     errors::ModelSelectionError,
     traits::{
@@ -24,7 +24,7 @@ pub struct ElphapexStockFirmware {}
 
 impl Display for ElphapexStockFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Elphapex Stock")
+        write!(f, "{}", FirmwareType::ElphapexStock)
     }
 }
 

--- a/asic-rs-firmwares/epic/src/firmware.rs
+++ b/asic-rs-firmwares/epic/src/firmware.rs
@@ -4,7 +4,7 @@ use asic_rs_core::traits::model::MinerModelAlgorithm;
 use asic_rs_core::{
     data::{
         command::MinerCommand,
-        device::{HashAlgorithm, MinerHardware},
+        device::{FirmwareType, HashAlgorithm, MinerHardware},
     },
     discovery::HTTP_WEB_ROOT,
     errors::ModelSelectionError,
@@ -96,7 +96,7 @@ pub struct EPicFirmware {}
 
 impl Display for EPicFirmware {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "UMC OS")
+        write!(f, "{}", FirmwareType::UmcOS)
     }
 }
 

--- a/asic-rs-firmwares/futurebit/src/firmware.rs
+++ b/asic-rs-firmwares/futurebit/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::HTTP_WEB_ROOT,
     errors::ModelSelectionError,
     traits::{
@@ -22,7 +22,7 @@ pub struct ApolloFirmware {}
 
 impl Display for ApolloFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "FutureBit Stock")
+        write!(f, "{}", FirmwareType::FutureBitStock)
     }
 }
 

--- a/asic-rs-firmwares/luxminer/src/firmware.rs
+++ b/asic-rs-firmwares/luxminer/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::{HTTP_WEB_ROOT, RPC_VERSION},
     errors::ModelSelectionError,
     traits::{
@@ -23,7 +23,7 @@ pub struct LuxMinerFirmware {}
 
 impl Display for LuxMinerFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "LuxOS")
+        write!(f, "{}", FirmwareType::LuxOS)
     }
 }
 

--- a/asic-rs-firmwares/marathon/src/firmware.rs
+++ b/asic-rs-firmwares/marathon/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::RPC_VERSION,
     errors::ModelSelectionError,
     traits::{
@@ -23,7 +23,7 @@ pub struct MarathonFirmware {}
 
 impl Display for MarathonFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Marathon")
+        write!(f, "{}", FirmwareType::Marathon)
     }
 }
 

--- a/asic-rs-firmwares/nerdaxe/src/firmware.rs
+++ b/asic-rs-firmwares/nerdaxe/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::HTTP_WEB_ROOT,
     errors::ModelSelectionError,
     traits::{
@@ -23,7 +23,7 @@ pub struct NerdAxeFirmware {}
 
 impl Display for NerdAxeFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Nerdaxe Stock")
+        write!(f, "{}", FirmwareType::NerdaxeStock)
     }
 }
 

--- a/asic-rs-firmwares/proto/src/firmware.rs
+++ b/asic-rs-firmwares/proto/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::HTTP_WEB_ROOT,
     errors::ModelSelectionError,
     traits::{
@@ -26,7 +26,7 @@ pub struct ProtoFirmware {}
 
 impl Display for ProtoFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Proto Stock")
+        write!(f, "{}", FirmwareType::ProtoStock)
     }
 }
 

--- a/asic-rs-firmwares/sealminer/src/firmware.rs
+++ b/asic-rs-firmwares/sealminer/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::{HTTP_WEB_ROOT, RPC_VERSION},
     errors::ModelSelectionError,
     traits::{
@@ -24,7 +24,7 @@ pub struct SealMinerStockFirmware {}
 
 impl Display for SealMinerStockFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "SealMiner Stock")
+        write!(f, "{}", FirmwareType::SealMinerStock)
     }
 }
 

--- a/asic-rs-firmwares/vnish/src/firmware.rs
+++ b/asic-rs-firmwares/vnish/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::{HTTP_WEB_ROOT, RPC_VERSION},
     errors::ModelSelectionError,
     traits::{
@@ -23,7 +23,7 @@ pub struct VnishFirmware {}
 
 impl Display for VnishFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "VNish")
+        write!(f, "{}", FirmwareType::VNish)
     }
 }
 

--- a/asic-rs-firmwares/volcminer/src/firmware.rs
+++ b/asic-rs-firmwares/volcminer/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::HTTP_WEB_ROOT,
     errors::ModelSelectionError,
     traits::{
@@ -25,7 +25,7 @@ pub struct VolcMinerStockFirmware {}
 
 impl Display for VolcMinerStockFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "VolcMiner Stock")
+        write!(f, "{}", FirmwareType::VolcMinerStock)
     }
 }
 

--- a/asic-rs-firmwares/whatsminer/src/backends/v2/mod.rs
+++ b/asic-rs-firmwares/whatsminer/src/backends/v2/mod.rs
@@ -14,7 +14,7 @@ use asic_rs_core::{
             DataCollector, DataExtensions, DataExtractor, DataField, DataLocation, get_by_pointer,
         },
         command::MinerCommand,
-        device::{DeviceInfo, HashAlgorithm},
+        device::{DeviceInfo, FirmwareType, HashAlgorithm},
         fan::FanData,
         hashrate::{HashRate, HashRateUnit},
         message::{MessageSeverity, MinerMessage},
@@ -797,12 +797,14 @@ fn tuning_config_to_rpc(config: &TuningConfig) -> anyhow::Result<(&'static str, 
             "adjust_power_limit",
             Some(json!({"power_limit": limit.as_watts().to_string()})),
         )),
-        TuningTarget::HashRate(_) => {
-            anyhow::bail!("HashRate tuning target is not supported on WhatsMiner")
-        }
-        TuningTarget::Preset(_) => {
-            anyhow::bail!("Preset tuning target is not supported on WhatsMiner")
-        }
+        TuningTarget::HashRate(_) => anyhow::bail!(
+            "HashRate tuning target is not supported on {}",
+            FirmwareType::WhatsMinerStock
+        ),
+        TuningTarget::Preset(_) => anyhow::bail!(
+            "Preset tuning target is not supported on {}",
+            FirmwareType::WhatsMinerStock
+        ),
     }
 }
 

--- a/asic-rs-firmwares/whatsminer/src/backends/v3/mod.rs
+++ b/asic-rs-firmwares/whatsminer/src/backends/v3/mod.rs
@@ -15,7 +15,7 @@ use asic_rs_core::{
             get_by_pointer,
         },
         command::MinerCommand,
-        device::{DeviceInfo, HashAlgorithm},
+        device::{DeviceInfo, FirmwareType, HashAlgorithm},
         fan::FanData,
         hashrate::{HashRate, HashRateUnit},
         message::{MessageSeverity, MinerMessage},
@@ -827,12 +827,14 @@ fn tuning_config_to_v3_rpc(config: &TuningConfig) -> anyhow::Result<(&'static st
             Ok(("set.miner.mode", json!(mode_str)))
         }
         TuningTarget::Power(limit) => Ok(("set.miner.power_limit", json!(limit.as_watts()))),
-        TuningTarget::HashRate(_) => {
-            anyhow::bail!("HashRate tuning target is not supported on WhatsMiner")
-        }
-        TuningTarget::Preset(_) => {
-            anyhow::bail!("Preset tuning target is not supported on WhatsMiner")
-        }
+        TuningTarget::HashRate(_) => anyhow::bail!(
+            "HashRate tuning target is not supported on {}",
+            FirmwareType::WhatsMinerStock
+        ),
+        TuningTarget::Preset(_) => anyhow::bail!(
+            "Preset tuning target is not supported on {}",
+            FirmwareType::WhatsMinerStock
+        ),
     }
 }
 

--- a/asic-rs-firmwares/whatsminer/src/firmware.rs
+++ b/asic-rs-firmwares/whatsminer/src/firmware.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use asic_rs_core::{
-    data::command::MinerCommand,
+    data::{command::MinerCommand, device::FirmwareType},
     discovery::{HTTP_WEB_ROOT, RPC_DEVDETAILS},
     errors::ModelSelectionError,
     traits::{
@@ -26,7 +26,7 @@ pub struct WhatsMinerFirmware {}
 
 impl Display for WhatsMinerFirmware {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "WhatsMiner Stock")
+        write!(f, "{}", FirmwareType::WhatsMinerStock)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a shared FirmwareType enum for firmware display names.
- Update firmware Display impls to use enum variants instead of raw string literals.
- Reuse FirmwareType in tuning-config unsupported-target messages for AntMiner and WhatsMiner.

## Validation
- cargo fmt
- cargo check *(blocked by existing lifetime-bound compiler limitation in asic-rs-core/src/traits/miner.rs:427)*