### PR TITLE
feat: add bitaxe 2.14.0 and update bitaxe functionality

### DIFF
--- a/asic-rs-firmwares/bitaxe/src/backends/mod.rs
+++ b/asic-rs-firmwares/bitaxe/src/backends/mod.rs
@@ -6,8 +6,10 @@ use asic_rs_core::traits::{
 };
 pub use v2_0_0::Bitaxe200;
 pub use v2_9_0::Bitaxe290;
+pub use v2_14_0::Bitaxe2140;
 
 pub mod v2_0_0;
+pub mod v2_14_0;
 pub mod v2_9_0;
 
 pub struct Bitaxe;
@@ -20,6 +22,8 @@ impl MinerConstructor for Bitaxe {
             Box::new(Bitaxe200::new(ip, model))
         } else if Bitaxe290::validate(version.as_ref()) {
             Box::new(Bitaxe290::new(ip, model))
+        } else if Bitaxe2140::validate(version.as_ref()) {
+            Box::new(Bitaxe2140::new(ip, model))
         } else {
             Box::new(Bitaxe290::new(ip, model))
         }

--- a/asic-rs-firmwares/bitaxe/src/backends/v2_0_0/mod.rs
+++ b/asic-rs-firmwares/bitaxe/src/backends/v2_0_0/mod.rs
@@ -17,6 +17,7 @@ use asic_rs_core::{
         fan::FanData,
         hashrate::{HashRate, HashRateUnit},
         message::{MessageSeverity, MinerMessage},
+        operating_state::OperatingState,
         pool::{PoolData, PoolGroupData, PoolScheme, PoolURL},
         share::parse_share_difficulty,
     },
@@ -84,6 +85,14 @@ impl GetDataLocations for Bitaxe200 {
         };
 
         match data_field {
+            DataField::OperatingState => vec![(
+                WEB_SYSTEM_INFO,
+                DataExtractor {
+                    func: get_by_key,
+                    key: Some("miningPaused"),
+                    tag: None,
+                },
+            )],
             DataField::Mac => vec![(
                 WEB_SYSTEM_INFO,
                 DataExtractor {
@@ -456,7 +465,19 @@ impl GetSessionBestShare for Bitaxe200 {
             .and_then(parse_share_difficulty)
     }
 }
-impl GetOperatingState for Bitaxe200 {}
+impl GetOperatingState for Bitaxe200 {
+    fn parse_operating_state(&self, data: &HashMap<DataField, Value>) -> Option<OperatingState> {
+        data.get(&DataField::OperatingState)
+            .and_then(Value::as_bool)
+            .map(|paused| {
+                if paused {
+                    OperatingState::Paused {}
+                } else {
+                    OperatingState::Mining {}
+                }
+            })
+    }
+}
 
 impl GetIsMining for Bitaxe200 {}
 impl GetPools for Bitaxe200 {

--- a/asic-rs-firmwares/bitaxe/src/backends/v2_14_0/mod.rs
+++ b/asic-rs-firmwares/bitaxe/src/backends/v2_14_0/mod.rs
@@ -30,22 +30,22 @@ use macaddr::MacAddr;
 use measurements::{AngularVelocity, Frequency, Power, Temperature, Voltage};
 use semver::Version;
 use serde_json::Value;
-use web::BitaxeWebAPI;
+use web::{Bitaxe2140WebAPI, BitaxeWebAPI};
 
 use crate::firmware::BitaxeFirmware;
 
 mod web;
 
 #[derive(Debug)]
-pub struct Bitaxe290 {
+pub struct Bitaxe2140 {
     ip: IpAddr,
     web: BitaxeWebAPI,
     device_info: DeviceInfo,
 }
 
-impl Bitaxe290 {
+impl Bitaxe2140 {
     pub fn new(ip: IpAddr, model: impl MinerModel) -> Self {
-        Bitaxe290 {
+        Bitaxe2140 {
             ip,
             web: BitaxeWebAPI::new(ip, 80),
             device_info: DeviceInfo::new(model, BitaxeFirmware::default(), HashAlgorithm::SHA256),
@@ -54,7 +54,7 @@ impl Bitaxe290 {
 }
 
 #[async_trait]
-impl APIClient for Bitaxe290 {
+impl APIClient for Bitaxe2140 {
     async fn get_api_result(&self, command: &MinerCommand) -> anyhow::Result<Value> {
         match command {
             MinerCommand::WebAPI { .. } => self.web.get_api_result(command).await,
@@ -63,21 +63,21 @@ impl APIClient for Bitaxe290 {
     }
 }
 
-impl GetConfigsLocations for Bitaxe290 {
+impl GetConfigsLocations for Bitaxe2140 {
     #[allow(unused_variables)]
     fn get_configs_locations(&self, data_field: ConfigField) -> Vec<ConfigLocation> {
         vec![]
     }
 }
 
-impl CollectConfigs for Bitaxe290 {
+impl CollectConfigs for Bitaxe2140 {
     fn get_config_collector(&self) -> ConfigCollector<'_> {
         ConfigCollector::new(self)
     }
 }
 
 #[async_trait]
-impl GetDataLocations for Bitaxe290 {
+impl GetDataLocations for Bitaxe2140 {
     fn get_locations(&self, data_field: DataField) -> Vec<DataLocation> {
         const WEB_SYSTEM_INFO: MinerCommand = MinerCommand::WebAPI {
             command: "system/info",
@@ -240,49 +240,49 @@ impl GetDataLocations for Bitaxe290 {
     }
 }
 
-impl GetIP for Bitaxe290 {
+impl GetIP for Bitaxe2140 {
     fn get_ip(&self) -> IpAddr {
         self.ip
     }
 }
-impl GetDeviceInfo for Bitaxe290 {
+impl GetDeviceInfo for Bitaxe2140 {
     fn get_device_info(&self) -> DeviceInfo {
         self.device_info.clone()
     }
 }
 
-impl CollectData for Bitaxe290 {
+impl CollectData for Bitaxe2140 {
     fn get_collector(&self) -> DataCollector<'_> {
         DataCollector::new(self)
     }
 }
 
-impl GetMAC for Bitaxe290 {
+impl GetMAC for Bitaxe2140 {
     fn parse_mac(&self, data: &HashMap<DataField, Value>) -> Option<MacAddr> {
         data.extract::<String>(DataField::Mac)
             .and_then(|s| MacAddr::from_str(&s).ok())
     }
 }
 
-impl GetSerialNumber for Bitaxe290 {
+impl GetSerialNumber for Bitaxe2140 {
     // N/A
 }
-impl GetHostname for Bitaxe290 {
+impl GetHostname for Bitaxe2140 {
     fn parse_hostname(&self, data: &HashMap<DataField, Value>) -> Option<String> {
         data.extract::<String>(DataField::Hostname)
     }
 }
-impl GetApiVersion for Bitaxe290 {
+impl GetApiVersion for Bitaxe2140 {
     fn parse_api_version(&self, data: &HashMap<DataField, Value>) -> Option<String> {
         data.extract::<String>(DataField::ApiVersion)
     }
 }
-impl GetFirmwareVersion for Bitaxe290 {
+impl GetFirmwareVersion for Bitaxe2140 {
     fn parse_firmware_version(&self, data: &HashMap<DataField, Value>) -> Option<String> {
         data.extract::<String>(DataField::FirmwareVersion)
     }
 }
-impl GetControlBoardVersion for Bitaxe290 {
+impl GetControlBoardVersion for Bitaxe2140 {
     fn parse_control_board_version(
         &self,
         data: &HashMap<DataField, Value>,
@@ -291,7 +291,7 @@ impl GetControlBoardVersion for Bitaxe290 {
             .and_then(|s| BitaxeControlBoard::parse(&s).map(|cb| cb.into()))
     }
 }
-impl GetHashboards for Bitaxe290 {
+impl GetHashboards for Bitaxe2140 {
     fn parse_hashboards(&self, data: &HashMap<DataField, Value>) -> Vec<BoardData> {
         let mut board = BoardData::new(0, self.device_info.hardware.chips_for_board(0));
 
@@ -365,7 +365,7 @@ impl GetHashboards for Bitaxe290 {
         vec![board]
     }
 }
-impl GetHashrate for Bitaxe290 {
+impl GetHashrate for Bitaxe2140 {
     fn parse_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         data.extract_map::<f64, _>(DataField::Hashrate, |f| {
             HashRate {
@@ -378,7 +378,7 @@ impl GetHashrate for Bitaxe290 {
     }
 }
 
-impl GetExpectedHashrate for Bitaxe290 {
+impl GetExpectedHashrate for Bitaxe2140 {
     fn parse_expected_hashrate(&self, data: &HashMap<DataField, Value>) -> Option<HashRate> {
         data.extract_map::<f64, _>(DataField::ExpectedHashrate, |f| {
             HashRate {
@@ -390,7 +390,7 @@ impl GetExpectedHashrate for Bitaxe290 {
         })
     }
 }
-impl GetFans for Bitaxe290 {
+impl GetFans for Bitaxe2140 {
     fn parse_fans(&self, data: &HashMap<DataField, Value>) -> Vec<FanData> {
         data.extract_map_or::<f64, _>(DataField::Fans, Vec::new(), |f| {
             vec![FanData {
@@ -400,28 +400,28 @@ impl GetFans for Bitaxe290 {
         })
     }
 }
-impl GetPsuFans for Bitaxe290 {
+impl GetPsuFans for Bitaxe2140 {
     // N/A
 }
-impl GetFluidTemperature for Bitaxe290 {
+impl GetFluidTemperature for Bitaxe2140 {
     // N/A
 }
-impl GetWattage for Bitaxe290 {
+impl GetWattage for Bitaxe2140 {
     fn parse_wattage(&self, data: &HashMap<DataField, Value>) -> Option<Power> {
         data.extract_map::<f64, _>(DataField::Wattage, Power::from_watts)
     }
 }
-impl GetTuningTarget for Bitaxe290 {
+impl GetTuningTarget for Bitaxe2140 {
     // N/A
 }
-impl GetScaledTuningTarget for Bitaxe290 {
+impl GetScaledTuningTarget for Bitaxe2140 {
     // N/A
 }
-impl GetTuningCapabilities for Bitaxe290 {}
-impl GetLightFlashing for Bitaxe290 {
+impl GetTuningCapabilities for Bitaxe2140 {}
+impl GetLightFlashing for Bitaxe2140 {
     // N/A
 }
-impl GetMessages for Bitaxe290 {
+impl GetMessages for Bitaxe2140 {
     fn parse_messages(&self, data: &HashMap<DataField, Value>) -> Vec<MinerMessage> {
         let mut messages = Vec::new();
         let timestamp = unix_timestamp_secs();
@@ -440,26 +440,26 @@ impl GetMessages for Bitaxe290 {
         messages
     }
 }
-impl GetUptime for Bitaxe290 {
+impl GetUptime for Bitaxe2140 {
     fn parse_uptime(&self, data: &HashMap<DataField, Value>) -> Option<Duration> {
         data.extract_map::<u64, _>(DataField::Uptime, Duration::from_secs)
     }
 }
 
-impl GetBestShare for Bitaxe290 {
+impl GetBestShare for Bitaxe2140 {
     fn parse_best_share(&self, data: &HashMap<DataField, Value>) -> Option<f64> {
         data.get(&DataField::BestShare)
             .and_then(parse_share_difficulty)
     }
 }
 
-impl GetSessionBestShare for Bitaxe290 {
+impl GetSessionBestShare for Bitaxe2140 {
     fn parse_session_best_share(&self, data: &HashMap<DataField, Value>) -> Option<f64> {
         data.get(&DataField::SessionBestShare)
             .and_then(parse_share_difficulty)
     }
 }
-impl GetOperatingState for Bitaxe290 {
+impl GetOperatingState for Bitaxe2140 {
     fn parse_operating_state(&self, data: &HashMap<DataField, Value>) -> Option<OperatingState> {
         data.get(&DataField::OperatingState)
             .and_then(Value::as_bool)
@@ -473,8 +473,8 @@ impl GetOperatingState for Bitaxe290 {
     }
 }
 
-impl GetIsMining for Bitaxe290 {}
-impl GetPools for Bitaxe290 {
+impl GetIsMining for Bitaxe2140 {}
+impl GetPools for Bitaxe2140 {
     fn parse_pools(&self, data: &HashMap<DataField, Value>) -> Vec<PoolGroupData> {
         let main_url =
             data.extract_nested_or::<String>(DataField::Pools, "stratumURL", String::new());
@@ -535,21 +535,21 @@ impl GetPools for Bitaxe290 {
 }
 
 #[async_trait]
-impl SetFaultLight for Bitaxe290 {
+impl SetFaultLight for Bitaxe2140 {
     fn supports_set_fault_light(&self) -> bool {
         false
     }
 }
 
 #[async_trait]
-impl SetPowerLimit for Bitaxe290 {
+impl SetPowerLimit for Bitaxe2140 {
     fn supports_set_power_limit(&self) -> bool {
         false
     }
 }
 
 #[async_trait]
-impl SupportsPoolsConfig for Bitaxe290 {
+impl SupportsPoolsConfig for Bitaxe2140 {
     async fn get_pools_config(&self) -> anyhow::Result<Vec<PoolGroupConfig>> {
         Ok(self
             .get_pools()
@@ -565,85 +565,95 @@ impl SupportsPoolsConfig for Bitaxe290 {
 }
 
 #[async_trait]
-impl Restart for Bitaxe290 {
+impl Restart for Bitaxe2140 {
     fn supports_restart(&self) -> bool {
         false
     }
 }
 
 #[async_trait]
-impl Pause for Bitaxe290 {
+impl Pause for Bitaxe2140 {
+    async fn pause(&self, _at_time: Option<Duration>) -> anyhow::Result<bool> {
+        self.web.pause().await?;
+        Ok(true)
+    }
+
     fn supports_pause(&self) -> bool {
-        false
+        true
     }
 }
 
 #[async_trait]
-impl Resume for Bitaxe290 {
+impl Resume for Bitaxe2140 {
+    async fn resume(&self, _at_time: Option<Duration>) -> anyhow::Result<bool> {
+        self.web.resume().await?;
+        Ok(true)
+    }
+
     fn supports_resume(&self) -> bool {
-        false
+        true
     }
 }
 
-impl ChangePassword for Bitaxe290 {
+impl ChangePassword for Bitaxe2140 {
     fn supports_change_password(&self) -> bool {
         false
     }
 }
 
-impl ReadLogs for Bitaxe290 {
+impl ReadLogs for Bitaxe2140 {
     fn supports_read_logs(&self) -> bool {
         false
     }
 }
 
-impl FactoryReset for Bitaxe290 {
+impl FactoryReset for Bitaxe2140 {
     fn supports_factory_reset(&self) -> bool {
         false
     }
 }
 
 #[async_trait]
-impl SupportsScalingConfig for Bitaxe290 {
+impl SupportsScalingConfig for Bitaxe2140 {
     fn supports_scaling_config(&self) -> bool {
         false
     }
 }
 
 #[async_trait]
-impl UpgradeFirmware for Bitaxe290 {
+impl UpgradeFirmware for Bitaxe2140 {
     fn supports_upgrade_firmware(&self) -> bool {
         false
     }
 }
 
-impl HasAuth for Bitaxe290 {}
-impl SupportsTimezoneConfig for Bitaxe290 {}
-impl HasDefaultAuth for Bitaxe290 {}
+impl HasAuth for Bitaxe2140 {}
+impl SupportsTimezoneConfig for Bitaxe2140 {}
+impl HasDefaultAuth for Bitaxe2140 {}
 
-impl Validate for Bitaxe290 {
+impl Validate for Bitaxe2140 {
     type Firmware = BitaxeFirmware;
 
     fn validate(version: Option<&semver::Version>) -> bool {
-        version.is_some_and(|v| *v >= Version::new(2, 9, 0) && *v < Version::new(2, 14, 0))
+        version.is_some_and(|v| *v >= Version::new(2, 14, 0))
     }
 }
 
 #[async_trait]
-impl SupportsTuningConfig for Bitaxe290 {
+impl SupportsTuningConfig for Bitaxe2140 {
     fn supports_tuning_config(&self) -> bool {
         false
     }
 }
 
 #[async_trait]
-impl SupportsFanConfig for Bitaxe290 {
+impl SupportsFanConfig for Bitaxe2140 {
     fn supports_fan_config(&self) -> bool {
         false
     }
 }
 
-impl SupportsTemperatureConfig for Bitaxe290 {}
-impl GetTuningPercent for Bitaxe290 {}
-impl SetTuningPercent for Bitaxe290 {}
-impl SupportsPresets for Bitaxe290 {}
+impl SupportsTemperatureConfig for Bitaxe2140 {}
+impl GetTuningPercent for Bitaxe2140 {}
+impl SetTuningPercent for Bitaxe2140 {}
+impl SupportsPresets for Bitaxe2140 {}

--- a/asic-rs-firmwares/bitaxe/src/backends/v2_14_0/web.rs
+++ b/asic-rs-firmwares/bitaxe/src/backends/v2_14_0/web.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use asic_rs_core::traits::miner::WebAPIClient;
+use async_trait::async_trait;
+use reqwest::Method;
+use serde_json::Value;
+
+pub use super::super::v2_0_0::web::BitaxeWebAPI;
+
+#[async_trait]
+#[allow(dead_code)]
+pub(crate) trait Bitaxe2140WebAPI: WebAPIClient {
+    /// Pause mining without restarting the device.
+    async fn pause(&self) -> Result<Value> {
+        self.send_command("system/pause", false, None, Method::POST)
+            .await
+    }
+
+    /// Resume mining after a pause.
+    async fn resume(&self) -> Result<Value> {
+        self.send_command("system/resume", false, None, Method::POST)
+            .await
+    }
+
+    /// Get ASIC information
+    async fn asic_info(&self) -> Result<Value> {
+        self.send_command("system/asic", false, None, Method::GET)
+            .await
+    }
+}
+
+impl Bitaxe2140WebAPI for BitaxeWebAPI {}

--- a/asic-rs-firmwares/bitaxe/src/firmware.rs
+++ b/asic-rs-firmwares/bitaxe/src/firmware.rs
@@ -55,8 +55,11 @@ impl MinerFirmware for BitaxeFirmware {
         }
     }
 
-    async fn get_version(_ip: IpAddr) -> Option<semver::Version> {
-        None
+    async fn get_version(ip: IpAddr) -> Option<semver::Version> {
+        let (text, _, _) = util::send_web_command(&ip, "/api/system/info").await?;
+        let json_data: serde_json::Value = serde_json::from_str(&text).ok()?;
+        let version_str = json_data["version"].as_str()?.trim_start_matches('v');
+        semver::Version::parse(version_str).ok()
     }
 }
 

--- a/asic-rs-firmwares/bitaxe/src/test/mod.rs
+++ b/asic-rs-firmwares/bitaxe/src/test/mod.rs
@@ -1,1 +1,98 @@
 pub(crate) mod json;
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, net::IpAddr};
+
+    use asic_rs_core::{
+        data::{
+            collector::{DataCollector, DataField},
+            command::MinerCommand,
+            operating_state::OperatingState,
+        },
+        test::api::MockAPIClient,
+        traits::miner::Miner,
+    };
+    use asic_rs_makes_bitaxe::models::BitaxeModel;
+    use serde_json::json;
+
+    use crate::backends::{Bitaxe200, Bitaxe290, Bitaxe2140};
+
+    #[tokio::test]
+    async fn operating_state_uses_explicit_pause_telemetry() {
+        let ip = IpAddr::from([127, 0, 0, 1]);
+        let miners: Vec<Box<dyn Miner>> = vec![
+            Box::new(Bitaxe200::new(ip, BitaxeModel::Supra)),
+            Box::new(Bitaxe290::new(ip, BitaxeModel::Supra)),
+            Box::new(Bitaxe2140::new(ip, BitaxeModel::Supra)),
+        ];
+        for miner in miners {
+            for (response, expected) in [
+                (
+                    json!({"miningPaused": true}),
+                    Some(OperatingState::Paused {}),
+                ),
+                (
+                    json!({"miningPaused": false}),
+                    Some(OperatingState::Mining {}),
+                ),
+                (json!({"hashRate": 500}), None),
+                (json!({"miningPaused": null}), None),
+                (json!({"miningPaused": "false"}), None),
+            ] {
+                let client = MockAPIClient::new(HashMap::from([(
+                    MinerCommand::WebAPI {
+                        command: "system/info",
+                        parameters: None,
+                    },
+                    response,
+                )]));
+                let mut collector = DataCollector::new_with_client(miner.as_ref(), &client);
+                let data = collector.collect(&[DataField::OperatingState]).await;
+                assert_eq!(miner.parse_operating_state(&data), expected);
+                assert_eq!(miner.parse_data(data).operating_state, expected);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn working_chips_uses_asic_info_without_chip_details() {
+        let ip = IpAddr::from([127, 0, 0, 1]);
+        let miners: Vec<Box<dyn Miner>> = vec![
+            Box::new(Bitaxe290::new(ip, BitaxeModel::Supra)),
+            Box::new(Bitaxe2140::new(ip, BitaxeModel::Supra)),
+        ];
+        for miner in miners {
+            for (system_info, asic_info, expected) in [
+                (json!({}), Some(json!({"asicCount": 1})), Some(1)),
+                (json!({}), Some(json!({"asicCount": 0})), Some(0)),
+                (json!({"asicCount": 1}), None, Some(1)),
+                (json!({}), None, None),
+            ] {
+                let mut responses = HashMap::from([(
+                    MinerCommand::WebAPI {
+                        command: "system/info",
+                        parameters: None,
+                    },
+                    system_info,
+                )]);
+                if let Some(info) = asic_info {
+                    responses.insert(
+                        MinerCommand::WebAPI {
+                            command: "system/asic",
+                            parameters: None,
+                        },
+                        info,
+                    );
+                }
+                let client = MockAPIClient::new(responses);
+                let mut collector = DataCollector::new_with_client(miner.as_ref(), &client);
+                let data = collector.collect(&[DataField::Hashboards]).await;
+                let boards = miner.parse_hashboards(&data);
+                assert!(boards[0].chips.is_empty());
+                assert_eq!(boards[0].working_chips, expected);
+                assert_eq!(miner.parse_data(data).total_chips, expected);
+            }
+        }
+    }
+}

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -18,7 +18,7 @@ Legend:
 | AntMiner Stock | :lucide-check-check: | :lucide-x: | :lucide-check-check: | :lucide-check-check: | :lucide-check-check: | :lucide-x: | :lucide-check-check: | :lucide-check-check: | :lucide-check-check: | :lucide-check-check: | :lucide-check-check: | :lucide-check-check: |
 | Auradine Stock | :lucide-check-check: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-check-check: | :lucide-check-check: | :lucide-check-check: | :lucide-check-check: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: |
 | AvalonMiner Stock | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-check-check: | :lucide-check-check: | :lucide-list-todo: | :lucide-check-check: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: |
-| Bitaxe Stock | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: |
+| Bitaxe Stock | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-list-todo: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: |
 | Braiins | :lucide-check-check: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-check-check: | :lucide-check-check: | :lucide-check-check: | :lucide-check-check: | :lucide-x: | :lucide-check-check: | :lucide-list-todo: | :lucide-check-check: |
 | Elphapex Stock | :lucide-check-check: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-check-check: | :lucide-x: | :lucide-check-check: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: |
 | FutureBit Stock | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: | :lucide-x: |


### PR DESCRIPTION
Adds pause/resume for latest bitaxe firmwares (added in 2.14.0), operating state, and fixes some existing bugs like not querying version for bitaxes and not having correct chip counts.